### PR TITLE
mutest: new exact_match flag for match and wait step

### DIFF
--- a/munet/mutest/userapi.py
+++ b/munet/mutest/userapi.py
@@ -393,12 +393,12 @@ class TestCase:
         self,
         target: str,
         cmd: str,
-    ) -> dict:
+    ) -> Union[list, dict]:
         """Execute a json ``cmd`` and return json result.
 
         Args:
             target: the target to execute the command on.
-            cmd: string to execut on the target.
+            cmd: string to execute on the target.
         """
         out = self.targets[target].cmd_nostatus(cmd, warn=False)
         self.last = out = out.rstrip()
@@ -420,6 +420,7 @@ class TestCase:
         match: str,
         expect_fail: bool,
         flags: int,
+        exact_match: bool,
     ) -> (bool, Union[str, list]):
         """Execute a ``cmd`` and check result.
 
@@ -429,6 +430,8 @@ class TestCase:
             match: regex to ``re.search()`` for in output.
             expect_fail: if True then succeed when the regexp doesn't match.
             flags: python regex flags to modify matching behavior
+            exact_match: if True then ``match`` must be exactly matched somewhere
+                in the output of ``cmd`` using ``str.find()``.
 
         Returns:
             (success, matches): if the match fails then "matches" will be None,
@@ -436,6 +439,17 @@ class TestCase:
             ``matches`` otherwise group(0) (i.e., the matching text).
         """
         out = self._command(target, cmd)
+        if exact_match:
+            if match not in out:
+                success = expect_fail
+                ret = None
+            else:
+                success = not expect_fail
+                ret = match
+                level = logging.DEBUG if success else logging.WARNING
+                self.olog.log(level, "exactly matched:%s:", ret)
+            return success, ret
+
         search = re.search(match, out, flags)
         self.last_m = search
         if search is None:
@@ -455,17 +469,19 @@ class TestCase:
         self,
         target: str,
         cmd: str,
-        match: Union[str, dict],
+        match: Union[str, list, dict],
         expect_fail: bool,
-    ) -> Union[str, dict]:
+        exact_match: bool,
+    ) -> (bool, Union[list, dict]):
         """Execute a json ``cmd`` and check result.
 
         Args:
             target: the target to execute the command on.
             cmd: string to execut on the target.
-            match: A json ``str`` or object (``dict``) to compare against the json
-                output from ``cmd``.
+            match: A json ``str``, object (``dict``), or array (``list``) to
+                compare against the json output from ``cmd``.
             expect_fail: if True then succeed when the json doesn't match.
+            exact_match: if True then the json must exactly match.
         """
         js = self._command_json(target, cmd)
         try:
@@ -476,7 +492,27 @@ class TestCase:
                 "JSON load failed. Check match value is in JSON format: %s", error
             )
 
-        if json_diff := json_cmp(expect, js):
+        if exact_match:
+            deep_diff = json_cmp(expect, js)
+            # Convert DeepDiff completely into dicts or lists at all levels
+            json_diff = json.loads(deep_diff.to_json())
+        else:
+            deep_diff = json_cmp(expect, js, ignore_order=True)
+            # Convert DeepDiff completely into dicts or lists at all levels
+            json_diff = json.loads(deep_diff.to_json())
+            # Remove new fields in json object from diff
+            if json_diff.get('dictionary_item_added') is not None:
+                del json_diff['dictionary_item_added']
+            # Remove new json objects in json array from diff
+            if (new_items := json_diff.get('iterable_item_added')) is not None:
+                new_item_paths = list(new_items.keys())
+                for path in new_item_paths:
+                    if type(new_items[path]) is dict:
+                        del new_items[path]
+                if len(new_items) == 0:
+                    del json_diff['iterable_item_added']
+
+        if json_diff:
             success = expect_fail
             if not success:
                 self.logf("JSON DIFF:%s:" % json_diff)
@@ -489,14 +525,24 @@ class TestCase:
         self,
         target: str,
         cmd: str,
-        match: Union[str, dict],
+        match: Union[str, list, dict],
         is_json: bool,
         timeout: float,
         interval: float,
         expect_fail: bool,
         flags: int,
-    ) -> Union[str, dict]:
-        """Execute a command repeatedly waiting for result until timeout."""
+        exact_match: bool,
+    ) -> Union[str, list, dict]:
+        """Execute a command repeatedly waiting for result until timeout.
+
+        ``match`` is a regular expression to search for in the output of ``cmd``
+        when ``is_json`` is False.
+
+        When ``is_json`` is True ``match`` must be a json object, a json array,
+        or a ``str`` which parses into a json object. Likewise, the ``cmd`` output
+        is parsed into a json object or array and then a comparison is done between
+        the two json objects or arrays.
+        """
         startt = time.time()
         endt = startt + timeout
 
@@ -504,10 +550,12 @@ class TestCase:
         ret = None
         while not success and time.time() < endt:
             if is_json:
-                success, ret = self._match_command_json(target, cmd, match, expect_fail)
+                success, ret = self._match_command_json(
+                    target, cmd, match, expect_fail, exact_match
+                )
             else:
                 success, ret = self._match_command(
-                    target, cmd, match, expect_fail, flags
+                    target, cmd, match, expect_fail, flags, exact_match
                 )
             if not success:
                 time.sleep(interval)
@@ -626,7 +674,7 @@ class TestCase:
         )
         return self._command(target, cmd)
 
-    def step_json(self, target: str, cmd: str) -> dict:
+    def step_json(self, target: str, cmd: str) -> Union[list, dict]:
         """See :py:func:`~munet.mutest.userapi.step_json`.
 
         :meta private:
@@ -649,13 +697,14 @@ class TestCase:
         desc: str = "",
         expect_fail: bool = False,
         flags: int = re.DOTALL,
+        exact_match: bool = False,
     ) -> (bool, Union[str, list]):
         """See :py:func:`~munet.mutest.userapi.match_step`.
 
         :meta private:
         """
         self.logf(
-            "#%s.%s:%s:MATCH_STEP:%s:%s:%s:%s:%s:%s",
+            "#%s.%s:%s:MATCH_STEP:%s:%s:%s:%s:%s:%s:%s",
             self.tag,
             self.steps + 1,
             self.info.path,
@@ -665,8 +714,11 @@ class TestCase:
             desc,
             expect_fail,
             flags,
+            exact_match,
         )
-        success, ret = self._match_command(target, cmd, match, expect_fail, flags)
+        success, ret = self._match_command(
+            target, cmd, match, expect_fail, flags, exact_match
+        )
         if desc:
             self.__post_result(target, success, desc)
         return success, ret
@@ -684,16 +736,17 @@ class TestCase:
         self,
         target: str,
         cmd: str,
-        match: Union[str, dict],
+        match: Union[str, list, dict],
         desc: str = "",
         expect_fail: bool = False,
-    ) -> (bool, Union[str, dict]):
+        exact_match: bool = False,
+    ) -> (bool, Union[list, dict]):
         """See :py:func:`~munet.mutest.userapi.match_step_json`.
 
         :meta private:
         """
         self.logf(
-            "#%s.%s:%s:MATCH_STEP_JSON:%s:%s:%s:%s:%s",
+            "#%s.%s:%s:MATCH_STEP_JSON:%s:%s:%s:%s:%s:%s",
             self.tag,
             self.steps + 1,
             self.info.path,
@@ -702,8 +755,11 @@ class TestCase:
             match,
             desc,
             expect_fail,
+            exact_match,
         )
-        success, ret = self._match_command_json(target, cmd, match, expect_fail)
+        success, ret = self._match_command_json(
+            target, cmd, match, expect_fail, exact_match
+        )
         if desc:
             self.__post_result(target, success, desc)
         return success, ret
@@ -718,8 +774,48 @@ class TestCase:
         interval=0.5,
         expect_fail: bool = False,
         flags: int = re.DOTALL,
+        exact_match: bool = False,
     ) -> (bool, Union[str, list]):
         """See :py:func:`~munet.mutest.userapi.wait_step`.
+
+        :meta private:
+        """
+        if interval is None:
+            interval = min(timeout / 20, 0.25)
+        self.logf(
+            "#%s.%s:%s:WAIT_STEP:%s:%s:%s:%s:%s:%s:%s:%s:%s",
+            self.tag,
+            self.steps + 1,
+            self.info.path,
+            target,
+            cmd,
+            match,
+            timeout,
+            interval,
+            desc,
+            expect_fail,
+            flags,
+            exact_match,
+        )
+        success, ret = self._wait(
+            target, cmd, match, False, timeout, interval, expect_fail, flags, exact_match
+        )
+        if desc:
+            self.__post_result(target, success, desc)
+        return success, ret
+
+    def wait_step_json(
+        self,
+        target: str,
+        cmd: str,
+        match: Union[str, list, dict],
+        desc: str = "",
+        timeout=10,
+        interval=None,
+        expect_fail: bool = False,
+        exact_match: bool = False,
+    ) -> (bool, Union[list, dict]):
+        """See :py:func:`~munet.mutest.userapi.wait_step_json`.
 
         :meta private:
         """
@@ -737,46 +833,10 @@ class TestCase:
             interval,
             desc,
             expect_fail,
-            flags,
+            exact_match,
         )
         success, ret = self._wait(
-            target, cmd, match, False, timeout, interval, expect_fail, flags
-        )
-        if desc:
-            self.__post_result(target, success, desc)
-        return success, ret
-
-    def wait_step_json(
-        self,
-        target: str,
-        cmd: str,
-        match: Union[str, dict],
-        desc: str = "",
-        timeout=10,
-        interval=None,
-        expect_fail: bool = False,
-    ) -> (bool, Union[str, dict]):
-        """See :py:func:`~munet.mutest.userapi.wait_step_json`.
-
-        :meta private:
-        """
-        if interval is None:
-            interval = min(timeout / 20, 0.25)
-        self.logf(
-            "#%s.%s:%s:WAIT_STEP:%s:%s:%s:%s:%s:%s:%s",
-            self.tag,
-            self.steps + 1,
-            self.info.path,
-            target,
-            cmd,
-            match,
-            timeout,
-            interval,
-            desc,
-            expect_fail,
-        )
-        success, ret = self._wait(
-            target, cmd, match, True, timeout, interval, expect_fail, 0
+            target, cmd, match, True, timeout, interval, expect_fail, 0, exact_match
         )
         if desc:
             self.__post_result(target, success, desc)
@@ -864,15 +924,15 @@ def step(target: str, cmd: str) -> str:
     return TestCase.g_tc.step(target, cmd)
 
 
-def step_json(target: str, cmd: str) -> dict:
-    """Execute a json ``cmd`` on a ``target`` and return the json object.
+def step_json(target: str, cmd: str) -> Union[list, dict]:
+    """Execute a json ``cmd`` on a ``target`` and return the json object or array.
 
     Args:
         target: the target to execute the ``cmd`` on.
         cmd: string to execute on the target.
 
     Returns:
-        Returns the json object after parsing the ``cmd`` output.
+        Returns the json object or array after parsing the ``cmd`` output.
 
         If json parse fails, a warning is logged and an empty ``dict`` is used.
     """
@@ -904,6 +964,7 @@ def match_step(
     desc: str = "",
     expect_fail: bool = False,
     flags: int = re.DOTALL,
+    exact_match: bool = False,
 ) -> (bool, Union[str, list]):
     """Execute a ``cmd`` on a ``target`` check result.
 
@@ -922,44 +983,53 @@ def match_step(
         desc: description of test, if no description then no result is logged.
         expect_fail: if True then succeed when the regexp doesn't match.
         flags: python regex flags to modify matching behavior
+        exact_match: if True then ``match`` must be exactly matched somewhere
+            in the output of ``cmd`` using ``str.find()``.
 
     Returns:
         Returns a 2-tuple. The first value is a bool indicating ``success``.
         The second value will be a list from ``re.Match.groups()`` if non-empty,
         otherwise ``re.Match.group(0)`` if there was a match otherwise None.
     """
-    return TestCase.g_tc.match_step(target, cmd, match, desc, expect_fail, flags)
+    return TestCase.g_tc.match_step(
+        target, cmd, match, desc, expect_fail, flags, exact_match
+    )
 
 
 def match_step_json(
     target: str,
     cmd: str,
-    match: Union[str, dict],
+    match: Union[str, list, dict],
     desc: str = "",
     expect_fail: bool = False,
-) -> (bool, Union[str, dict]):
+    exact_match: bool = False,
+) -> (bool, Union[list, dict]):
     """Execute a ``cmd`` on a ``target`` check result.
 
-    Execute ``cmd`` on ``target`` and check if the json object in ``match``
+    Execute ``cmd`` on ``target`` and check if the json object or array in ``match``
     matches or doesn't match (according to the ``expect_fail`` value) the
     json output from ``cmd``.
 
     Args:
         target: the target to execute the ``cmd`` on.
         cmd: string to execut on the ``target``.
-        match: A json ``str`` or object (``dict``) to compare against the json
-            output from ``cmd``.
+        match: A json ``str``, object (``dict``), or array (``list``) to compare
+            against the json output from ``cmd``.
         desc: description of test, if no description then no result is logged.
         expect_fail: if True then succeed if the a json doesn't match.
+        exact_match: if True then the json must exactly match.
 
     Returns:
         Returns a 2-tuple. The first value is a bool indicating ``success``. The
-        second value is a ``str`` diff if there is a difference found in the json
-        compare, otherwise the value is the json object (``dict``) from the ``cmd``.
+        second value is a ``dict`` of the diff if there is a difference found in
+        the json compare, otherwise the value is the json object (``dict``) or
+        array (``list``) from the ``cmd``.
 
         If json parse fails, a warning is logged and an empty ``dict`` is used.
     """
-    return TestCase.g_tc.match_step_json(target, cmd, match, desc, expect_fail)
+    return TestCase.g_tc.match_step_json(
+        target, cmd, match, desc, expect_fail, exact_match
+    )
 
 
 def wait_step(
@@ -971,6 +1041,7 @@ def wait_step(
     interval: float = 0.5,
     expect_fail: bool = False,
     flags: int = re.DOTALL,
+    exact_match: bool = False,
 ) -> (bool, Union[str, list]):
     """Execute a ``cmd`` on a ``target`` repeatedly, looking for a result.
 
@@ -991,6 +1062,8 @@ def wait_step(
         desc: description of test, if no description then no result is logged.
         expect_fail: if True then succeed when the regexp *doesn't* match.
         flags: python regex flags to modify matching behavior
+        exact_match: if True then ``match`` must be exactly matched somewhere
+            in the output of ``cmd`` using ``str.find()``.
 
     Returns:
         Returns a 2-tuple. The first value is a bool indicating ``success``.
@@ -998,37 +1071,31 @@ def wait_step(
         otherwise ``re.Match.group(0)`` if there was a match otherwise None.
     """
     return TestCase.g_tc.wait_step(
-        target, cmd, match, desc, timeout, interval, expect_fail, flags
+        target, cmd, match, desc, timeout, interval, expect_fail, flags, exact_match
     )
 
 
 def wait_step_json(
     target: str,
     cmd: str,
-    match: Union[str, dict],
+    match: Union[str, list, dict],
     desc: str = "",
     timeout=10,
     interval=None,
     expect_fail: bool = False,
-) -> (bool, Union[str, dict]):
+    exact_match: bool = False,
+) -> (bool, Union[list, dict]):
     """Execute a cmd repeatedly and wait for matching result.
 
     Execute ``cmd`` on ``target``, every ``interval`` seconds until
     the output of ``cmd`` matches or doesn't match (according to the
     ``expect_fail`` value) ``match``, for up to ``timeout`` seconds.
 
-    ``match`` is a regular expression to search for in the output of ``cmd`` when
-    ``is_json`` is False.
-
-    When ``is_json`` is True ``match`` must be a json object or a ``str`` which
-    parses into a json object. Likewise, the ``cmd`` output is parsed into a json
-    object and then a comparison is done between the two json objects.
-
     Args:
         target: the target to execute the ``cmd`` on.
         cmd: string to execut on the ``target``.
-        match: A json object or str representation of one to compare against json
-            output from ``cmd``.
+        match: A json object, json array, or str representation of json to compare
+            against json output from ``cmd``.
         desc: description of test, if no description then no result is logged.
         timeout: The number of seconds to repeat the ``cmd`` looking for a match
             (or non-match if ``expect_fail`` is True).
@@ -1037,17 +1104,18 @@ def wait_step_json(
             average the cmd will execute 10 times. The minimum calculated interval
             is .25s, shorter values can be passed explicitly.
         expect_fail: if True then succeed if the a json doesn't match.
+        exact_match: if True then the json must exactly match.
 
     Returns:
         Returns a 2-tuple. The first value is a bool indicating ``success``.
-        The second value is a ``str`` diff if there is a difference found in the
-        json compare, otherwise the value is a json object (dict) from the ``cmd``
-        output.
+        The second value is a ``dict`` of the diff if there is a difference
+        found in the json compare, otherwise the value is a json object (``dict``)
+        or array (``list``) from the ``cmd`` output.
 
         If json parse fails, a warning is logged and an empty ``dict`` is used.
     """
     return TestCase.g_tc.wait_step_json(
-        target, cmd, match, desc, timeout, interval, expect_fail
+        target, cmd, match, desc, timeout, interval, expect_fail, exact_match
     )
 
 

--- a/tests/mutest/mutest_matchwait.py
+++ b/tests/mutest/mutest_matchwait.py
@@ -45,6 +45,16 @@ wait_step(
     0.25,
     expect_fail=False,
 )
+wait_step(
+    "r1",
+    'sleep .5 && echo -e "exact\nmatch"',
+    "exact\nmatch",
+    "Look for exact match",
+    1,
+    0.25,
+    expect_fail=False,
+    exact_match=True,
+)
 
 section("Test negative (expect_fail) match_step calls")
 
@@ -72,4 +82,14 @@ wait_step(
     timeout=1,
     interval=0.25,
     expect_fail=True,
+)
+wait_step(
+    "host1",
+    'sleep .5 && echo -e "exact\nmatch"',
+    "not exact",
+    "Look for no exact match",
+    1,
+    0.25,
+    expect_fail=True,
+    exact_match=True,
 )

--- a/tests/mutest/mutest_matchwait_json.py
+++ b/tests/mutest/mutest_matchwait_json.py
@@ -130,3 +130,188 @@ wait_step_json(
 wait_step_json(
     "r1", """echo 'not json'""", '{ "name": "other" }', "Look for chopps", 1, 0.25, True
 )
+
+section("Test json exact matching (exact_match == True)")
+
+match_step_json(
+    "r1",
+    """echo '[{ "name": "other" }]'""",
+    '[{ "name": "chopps"}]',
+    "Look for no chopps",
+    expect_fail=True,
+    exact_match=True,
+)
+wait_step_json(
+    "r1",
+    """echo '[{ "name": "other" }]'""",
+    '[{ "name": "chopps"}]',
+    "Look for no chopps",
+    1,
+    expect_fail=True,
+    exact_match=True,
+)
+match_step_json(
+    "r1",
+    """echo '[{ "name": "chopps" }]'""",
+    '[{ "name": "chopps"}]',
+    "Look for chopps",
+    exact_match=True,
+)
+wait_step_json(
+    "r1",
+    """echo '[{ "name": "chopps" }]'""",
+    '[{ "name": "chopps"}]',
+    "Look for chopps",
+    1,
+    exact_match=True,
+)
+
+section("Test json matching rules (exact_match == False)")
+
+json1 = '{"foo":"foo"}'
+json2 = '{"foo":"foo", "bar":"bar"}'
+
+_, ret = match_step_json(
+    "r1",
+    f"echo '{json2}'",
+    json1,
+    "Data within output object present",
+)
+test_step(
+    ret == {'foo': 'foo', 'bar': 'bar'},
+    "    Correct return value",
+)
+_, ret = match_step_json(
+    "r1",
+    f"echo '{json1}'",
+    json2,
+    "Data within output object not present",
+    expect_fail=True,
+)
+test_step(
+    ret == {'dictionary_item_removed': ["root['bar']"]},
+    "    Correct return value",
+)
+# The return type should be a mix of dicts and lists. Not custom DeepDiff types!
+test_step(
+    type(ret['dictionary_item_removed']) is list,
+    "    Correct return value type",
+)
+
+json1 = '[{"foo":"foo"}]'
+json2 = '[{"foo":"foo"}, {"bar":"bar"}]'
+json3 = '[{"bar":"bar"}, {"foo":"foo"}]'
+
+_, ret = match_step_json(
+    "r1",
+    f"echo '{json2}'",
+    json1,
+    "Objects within output array present",
+)
+test_step(
+    ret == [{'foo': 'foo'}, {'bar': 'bar'}],
+    "    Correct return value",
+)
+_, ret = match_step_json(
+    "r1",
+    f"echo '{json1}'",
+    json2,
+    "Objects within output array not present",
+    expect_fail=True,
+)
+test_step(
+    ret == {'iterable_item_removed': {'root[1]': {'bar': 'bar'}}},
+    "    Correct return value",
+)
+_, ret = match_step_json(
+    "r1",
+    f"echo '{json2}'",
+    json3,
+    "Both objects within output array present",
+)
+test_step(
+    ret == [{'foo': 'foo'}, {'bar': 'bar'}],
+    "    Correct return value",
+)
+
+json1 = '["foo"]'
+json2 = '["foo", "bar"]'
+json3 = '["bar", "foo"]'
+
+_, ret = match_step_json(
+    "r1",
+    f"echo '{json2}'",
+    json1,
+    "Data in different arrays don't match",
+    expect_fail=True,
+)
+test_step(
+    ret == {'iterable_item_added': {'root[1]': 'bar'}},
+    "    Correct return value",
+)
+_, ret = match_step_json(
+    "r1",
+    f"echo '{json1}'",
+    json2,
+    "Data in different arrays don't match",
+    expect_fail=True,
+)
+test_step(
+    ret == {'iterable_item_removed': {'root[1]': 'bar'}},
+    "    Correct return value",
+)
+_, ret = match_step_json(
+    "r1",
+    f"echo '{json2}'",
+    json3,
+    "Data in equivalent arrays match"
+)
+test_step(
+    ret == ['foo', 'bar'],
+    "    Correct return value",
+)
+
+json1 = '{"level1": ["level2", {"level3": ["level4"]}]}'
+json2 = '{"level1": ["level2", {"level3": ["level4"], "l3": "l4"}]}'
+json3 = '{"level1": ["level2", {"level3": ["level4", {"level5": "l6"}]}]}'
+json4 = '{"level1": ["level2", {"level3": ["level4", "l4"]}]}'
+
+_, ret = match_step_json(
+    "r1",
+    f"echo '{json2}'",
+    json1,
+    "Data within output object present (nested)",
+)
+test_step(
+    ret == {'level1': ['level2', {'level3': ['level4'], 'l3': 'l4'}]},
+    "    Correct return value",
+)
+_, ret = match_step_json(
+    "r1",
+    f"echo '{json3}'",
+    json1,
+    "Objects within output array present (nested)",
+)
+test_step(
+    ret == {'level1': ['level2', {'level3': ['level4', {'level5': 'l6'}]}]},
+    "    Correct return value",
+)
+_, ret = match_step_json(
+    "r1",
+    f"echo '{json4}'",
+    json1,
+    "Data in different arrays don't match (nested)",
+    expect_fail=True
+)
+test_step(
+    ret == {'iterable_item_added': {"root['level1'][1]['level3'][1]": 'l4'}},
+    "    Correct return value",
+)
+match_step_json(
+    "r1",
+    """echo '{}'""",
+    '{ "name": "chopps"}',
+    "empty json output doesn't match",
+    expect_fail=True,
+    exact_match=False,
+)


### PR DESCRIPTION
Adds in new exact_match flag for (in)exact matching. This results in the following states:

For the match and wait steps (non-json):
- If true, then search for the provided string exactly within the command output (substring match). (new behavior)
- If false, then perform a regex search on the command output using the provided pattern.

For the match_json and wait_json steps:
- If true, then exactly match the provided and output json against each other.
- If false, then both search for and match the provided json's fields against those in the cmd output (but not vice versa). (new behavior)
    - The exact rules for matching in this case have been added to the munet documentation source files

And the new default behavior of munet is for exact matching to be set to false.
- This changes the default behavior of json matching, which previously was always an exact match