### PR TITLE
examples: new PIM-SM examples in FRRouting

### DIFF
--- a/examples/frr/README.md
+++ b/examples/frr/README.md
@@ -5,3 +5,4 @@ The following directories contain FRRouting simulations for the following
 protocols:
 
 * `./ospf`          OSPFv2
+* `./pim`           PIM and IGMP

--- a/examples/frr/pim/README.md
+++ b/examples/frr/pim/README.md
@@ -1,0 +1,9 @@
+PIM and IGMP FRRouting Simulations
+==================================
+
+The following directories contain simulations showcasing PIM-SM features:
+
+* `./asm`                 Any Source Multicast (ASM)
+* `./ssm`                 Source Specific Multicast (SSM)
+* `./spt-switchover`      Shortest Path Tree (SPT) Switchover
+* `./assert`              PIM Assert

--- a/examples/frr/pim/asm/README.md
+++ b/examples/frr/pim/asm/README.md
@@ -1,0 +1,48 @@
+Any Source Multicast (ASM) Simulation
+=====================================
+
+This simulation demonstrates the configuration of ASM Multicast via PIM and IGMP
+in FRRouting through Munet. The network also utilizes OSPF to populate all
+routing tables.
+
+```
+
+   +------+                                              +------+
+   | src- |  <-- Source of 224.1.1.1                     | rec- |
+   | rtr1 |                                              | rtr3 |
+   |      |                    (*, 224.1.1.1) Member --> |      |
+   +--+---+                                              +--+---+
+      |.10                                                  |.10
+      |                                                     |
+      | 11.0.1.0/24                                         | 11.0.3.0/24
+      | local-rtr1                                          | local-rtr3
+      |                                                     |
+      |.1                                                   |.3
+   +--+---+                                              +--+---+
+   |      |   10.0.1.0/24                  10.0.2.0/24   |      |
+   | rtr1 +----------------\            /----------------+ rtr3 |
+   |      |.1    net1       \          /      net2     .3|      |
+   +------+                  \.2      /.2                +------+
+                              +------+
+                              |      |
+                              | rtr2 |
+                              | (RP) |
+                              +--+---+
+                                 |.2  \.2                +------+
+                                 |     \   10.0.3.0/24   |      |
+                                 |      \----------------+ rtr4 |
+       No Multicast packets! --> |            net3     .4|      |
+                                 |                       +--+---+
+                                 | 10.0.5.0/24              |.4
+                                 | net4                     |
+                                 |                          | 11.0.4.0/24
+                                 |.5                        | local-rtr4
+                              +--+---+                      |
+                              |      |                      |.10
+                              | rtr5 |                   +--+---+
+                              |      |                   | rec- |
+                              +------+                   | rtr4 |
+                                                         |      |
+                               (*, 224.1.1.1) Member --> +------+
+
+```

--- a/examples/frr/pim/asm/munet.yaml
+++ b/examples/frr/pim/asm/munet.yaml
@@ -1,0 +1,89 @@
+version: 1
+kinds:
+  - name: frr
+    cmd: |
+      chown frr:frr -R /var/run/frr
+      chown frr:frr -R /var/log/frr
+      /usr/lib/frr/frrinit.sh start
+      tail -F /var/log/frr/frr.log
+    cleanup-cmd: |
+      /usr/lib/frr/frrinit.sh stop
+    volumes:
+      - "./%NAME%/etc.frr:/etc/frr"
+      - "%RUNDIR%/var.log.frr:/var/log/frr"
+      - "%RUNDIR%/var.run.frr:/var/run/frr"
+    cap-add:
+      - SYS_ADMIN
+      - AUDIT_WRITE
+    merge: ["volumes"]
+
+topology:
+  networks:
+    - name: net1
+      ip: 10.0.1.254/24
+    - name: net2
+      ip: 10.0.2.254/24
+    - name: net3
+      ip: 10.0.3.254/24
+    - name: net4
+      ip: 10.0.4.254/24
+    - name: local-rtr3
+      ip: 11.0.3.254/24
+    - name: local-rtr4
+      ip: 11.0.4.254/24
+    - name: local-rtr1
+      ip: 11.0.1.254/24
+  nodes:
+    - name: rtr1
+      kind: frr
+      connections:
+        - to: "net1"
+        - to: "local-rtr1"
+    - name: src-rtr1
+      connections:
+        - to: "local-rtr1"
+      cmd: |
+        ip address add 11.0.1.10/24 dev eth0
+        ip route add default via 11.0.1.1
+        ping 224.1.1.1 -t 128
+    - name: rtr2
+      kind: frr
+      connections:
+        - to: "net1"
+        - to: "net2"
+        - to: "net3"
+        - to: "net4"
+    - name: rtr3
+      kind: frr
+      connections:
+        - to: "net2"
+        - to: "local-rtr3"
+    - name: rec-rtr3
+      kind: frr
+      connections:
+        - to: "local-rtr3"
+    - name: rtr4
+      kind: frr
+      connections:
+        - to: "net3"
+        - to: "local-rtr4"
+    - name: rec-rtr4
+      kind: frr
+      connections:
+        - to: "local-rtr4"
+    - name: rtr5
+      kind: frr
+      connections:
+        - to: "net4"
+cli:
+  commands:
+    - name: ""
+      exec: "vtysh -c '{}'"
+      format: "[ROUTER ...] COMMAND"
+      help: "execute vtysh COMMAND on the router[s]"
+      kinds: ["frr"]
+    - name: "vtysh"
+      exec: "/usr/bin/vtysh"
+      format: "vtysh ROUTER [ROUTER ...]"
+      new-window: true
+      kinds: ["frr"]

--- a/examples/frr/pim/asm/rec-rtr3/etc.frr/daemons
+++ b/examples/frr/pim/asm/rec-rtr3/etc.frr/daemons
@@ -1,0 +1,7 @@
+zebra=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/asm/rec-rtr3/etc.frr/frr.conf
+++ b/examples/frr/pim/asm/rec-rtr3/etc.frr/frr.conf
@@ -1,0 +1,9 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+ip route 0.0.0.0/0 11.0.3.3 eth0
+
+interface eth0
+ ip address 11.0.3.10/24
+ ip igmp
+ ip igmp join 224.1.1.1

--- a/examples/frr/pim/asm/rec-rtr3/etc.frr/vtysh.conf
+++ b/examples/frr/pim/asm/rec-rtr3/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/asm/rec-rtr4/etc.frr/daemons
+++ b/examples/frr/pim/asm/rec-rtr4/etc.frr/daemons
@@ -1,0 +1,7 @@
+zebra=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/asm/rec-rtr4/etc.frr/frr.conf
+++ b/examples/frr/pim/asm/rec-rtr4/etc.frr/frr.conf
@@ -1,0 +1,9 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+ip route 0.0.0.0/0 11.0.4.4 eth0
+
+interface eth0
+ ip address 11.0.4.10/24
+ ip igmp
+ ip igmp join 224.1.1.1

--- a/examples/frr/pim/asm/rec-rtr4/etc.frr/vtysh.conf
+++ b/examples/frr/pim/asm/rec-rtr4/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/asm/rtr1/etc.frr/daemons
+++ b/examples/frr/pim/asm/rtr1/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/asm/rtr1/etc.frr/frr.conf
+++ b/examples/frr/pim/asm/rtr1/etc.frr/frr.conf
@@ -1,0 +1,22 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.1.1/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 11.0.1.1/24
+ ip pim
+ ip pim passive
+ ip igmp
+
+ip pim rp 10.0.1.2 224.1.1.0/24
+
+router ospf
+ ospf router-id 172.16.0.1
+ network 10.0.0.0/16 area 0.0.0.0
+ redistribute connected

--- a/examples/frr/pim/asm/rtr1/etc.frr/vtysh.conf
+++ b/examples/frr/pim/asm/rtr1/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/asm/rtr2/etc.frr/daemons
+++ b/examples/frr/pim/asm/rtr2/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/asm/rtr2/etc.frr/frr.conf
+++ b/examples/frr/pim/asm/rtr2/etc.frr/frr.conf
@@ -1,0 +1,41 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.1.2/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 10.0.2.2/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth2
+ ip address 10.0.3.2/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth3
+ ip address 10.0.4.2/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth4
+ ip address 10.0.5.2/24
+ ip pim
+ ip igmp
+
+ip pim rp 10.0.1.2 224.1.1.0/24
+
+router ospf
+ ospf router-id 172.16.0.2
+ network 10.0.0.0/16 area 0.0.0.0

--- a/examples/frr/pim/asm/rtr2/etc.frr/vtysh.conf
+++ b/examples/frr/pim/asm/rtr2/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/asm/rtr3/etc.frr/daemons
+++ b/examples/frr/pim/asm/rtr3/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/asm/rtr3/etc.frr/frr.conf
+++ b/examples/frr/pim/asm/rtr3/etc.frr/frr.conf
@@ -1,0 +1,22 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.2.3/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 11.0.3.3/24
+ ip pim
+ ip pim passive
+ ip igmp
+
+ip pim rp 10.0.1.2 224.1.1.0/24
+
+router ospf
+ ospf router-id 172.16.0.3
+ network 10.0.0.0/16 area 0.0.0.0
+ redistribute connected

--- a/examples/frr/pim/asm/rtr3/etc.frr/vtysh.conf
+++ b/examples/frr/pim/asm/rtr3/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/asm/rtr4/etc.frr/daemons
+++ b/examples/frr/pim/asm/rtr4/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/asm/rtr4/etc.frr/frr.conf
+++ b/examples/frr/pim/asm/rtr4/etc.frr/frr.conf
@@ -1,0 +1,22 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.3.4/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 11.0.4.4/24
+ ip pim
+ ip pim passive
+ ip igmp
+
+ip pim rp 10.0.1.2 224.1.1.0/24
+
+router ospf
+ ospf router-id 172.16.0.4
+ network 10.0.0.0/16 area 0.0.0.0
+ redistribute connected

--- a/examples/frr/pim/asm/rtr4/etc.frr/vtysh.conf
+++ b/examples/frr/pim/asm/rtr4/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/asm/rtr5/etc.frr/daemons
+++ b/examples/frr/pim/asm/rtr5/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/asm/rtr5/etc.frr/frr.conf
+++ b/examples/frr/pim/asm/rtr5/etc.frr/frr.conf
@@ -1,0 +1,15 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.4.5/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+ip pim rp 10.0.1.2 224.1.1.0/24
+
+router ospf
+ ospf router-id 172.16.0.5
+ network 10.0.0.0/16 area 0.0.0.0

--- a/examples/frr/pim/asm/rtr5/etc.frr/vtysh.conf
+++ b/examples/frr/pim/asm/rtr5/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/assert/README.md
+++ b/examples/frr/pim/assert/README.md
@@ -1,0 +1,33 @@
+PIM Assert Simulation
+=====================
+
+This simulation demonstrates the PIM assert process through an example topology
+in FRRouting through Munet. rtr2 and rtr3 will share metrics following the PIM
+assert process and determine a winner. The other router gets pruned, therefore
+avoiding duplicate traffic. In this case, rtr2 is configured to have a lower
+metric than rtr3, and therefore will be selected as the winner. The network also
+utilizes OSPF to populate all routing tables.
+
+```
+
+   +------+                                                  +------+
+   | src- |  <-- Source of 224.1.1.1                         | rec- |
+   | rtr1 |                                                  | rtr4 |
+   |      |                        (*, 224.1.1.1) Member --> |      |
+   +--+---+                                                  +--+---+
+      |.10                               Metric: 5              |.10
+      |                         +------+ |                      |
+      | 11.0.1.0/24             |      | V                      | 11.0.4.0/24
+      | local-rtr1          /---+ rtr2 +---\                    | local-rtr4
+      |                    /  .2|      |.2  \                   |
+      |.1                  |    +------+    |                   |.4
+   +--+---+                |                |                +--+---+
+   |      |   10.0.1.0/24  |                |  10.0.2.0/24   |      |
+   | rtr1 +----------------|                |----------------+ rtr4 |
+   |      |.1    net1      |    +------+    |     net2     .4|      |
+   +------+                \  .3|      |.3  /                +------+
+                            \---+ rtr3 +---/ 
+                                |      | ^
+                                +------+ |
+                                         Metric: 10
+```

--- a/examples/frr/pim/assert/munet.yaml
+++ b/examples/frr/pim/assert/munet.yaml
@@ -1,0 +1,73 @@
+version: 1
+kinds:
+  - name: frr
+    cmd: |
+      chown frr:frr -R /var/run/frr
+      chown frr:frr -R /var/log/frr
+      /usr/lib/frr/frrinit.sh start
+      tail -F /var/log/frr/frr.log
+    cleanup-cmd: |
+      /usr/lib/frr/frrinit.sh stop
+    volumes:
+      - "./%NAME%/etc.frr:/etc/frr"
+      - "%RUNDIR%/var.log.frr:/var/log/frr"
+      - "%RUNDIR%/var.run.frr:/var/run/frr"
+    cap-add:
+      - SYS_ADMIN
+      - AUDIT_WRITE
+    merge: ["volumes"]
+
+topology:
+  networks:
+    - name: net1
+      ip: 10.0.1.254/24
+    - name: net2
+      ip: 10.0.2.254/24
+    - name: local-rtr1
+      ip: 11.0.1.254/24
+    - name: local-rtr4
+      ip: 11.0.4.254/24
+  nodes:
+    - name: rtr1
+      kind: frr
+      connections:
+        - to: "net1"
+        - to: "local-rtr1"
+    - name: src-rtr1
+      connections:
+        - to: "local-rtr1"
+      cmd: |
+        ip address add 11.0.1.10/24 dev eth0
+        ip route add default via 11.0.1.1
+        ping 224.1.1.1 -t 128
+    - name: rtr2
+      kind: frr
+      connections:
+        - to: "net1"
+        - to: "net2"
+    - name: rtr3
+      kind: frr
+      connections:
+        - to: "net1"
+        - to: "net2"
+    - name: rtr4
+      kind: frr
+      connections:
+        - to: "net2"
+        - to: "local-rtr4"
+    - name: rec-rtr4
+      kind: frr
+      connections:
+        - to: "local-rtr4"
+cli:
+  commands:
+    - name: ""
+      exec: "vtysh -c '{}'"
+      format: "[ROUTER ...] COMMAND"
+      help: "execute vtysh COMMAND on the router[s]"
+      kinds: ["frr"]
+    - name: "vtysh"
+      exec: "/usr/bin/vtysh"
+      format: "vtysh ROUTER [ROUTER ...]"
+      new-window: true
+      kinds: ["frr"]

--- a/examples/frr/pim/assert/rec-rtr4/etc.frr/daemons
+++ b/examples/frr/pim/assert/rec-rtr4/etc.frr/daemons
@@ -1,0 +1,7 @@
+zebra=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/assert/rec-rtr4/etc.frr/frr.conf
+++ b/examples/frr/pim/assert/rec-rtr4/etc.frr/frr.conf
@@ -1,0 +1,9 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+ip route 0.0.0.0/0 11.0.4.4 eth0
+
+interface eth0
+ ip address 11.0.4.10/24
+ ip igmp
+ ip igmp join 224.1.1.1

--- a/examples/frr/pim/assert/rec-rtr4/etc.frr/vtysh.conf
+++ b/examples/frr/pim/assert/rec-rtr4/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/assert/rtr1/etc.frr/daemons
+++ b/examples/frr/pim/assert/rtr1/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/assert/rtr1/etc.frr/frr.conf
+++ b/examples/frr/pim/assert/rtr1/etc.frr/frr.conf
@@ -1,0 +1,22 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.1.1/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 11.0.1.1/24
+ ip pim
+ ip pim passive
+ ip igmp
+
+ip pim rp 11.0.1.1 224.1.1.0/24
+
+router ospf
+ ospf router-id 172.16.0.1
+ network 10.0.0.0/16 area 0.0.0.0
+ redistribute connected

--- a/examples/frr/pim/assert/rtr1/etc.frr/vtysh.conf
+++ b/examples/frr/pim/assert/rtr1/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/assert/rtr2/etc.frr/daemons
+++ b/examples/frr/pim/assert/rtr2/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/assert/rtr2/etc.frr/frr.conf
+++ b/examples/frr/pim/assert/rtr2/etc.frr/frr.conf
@@ -1,0 +1,24 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.1.2/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+ ! Provide a better metric that guarentees assert victory
+ ip ospf cost 5
+
+interface eth1
+ ip address 10.0.2.2/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+ip pim rp 11.0.1.1 224.1.1.0/24
+
+router ospf
+ ospf router-id 172.16.0.2
+ network 10.0.0.0/16 area 0.0.0.0

--- a/examples/frr/pim/assert/rtr2/etc.frr/vtysh.conf
+++ b/examples/frr/pim/assert/rtr2/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/assert/rtr3/etc.frr/daemons
+++ b/examples/frr/pim/assert/rtr3/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/assert/rtr3/etc.frr/frr.conf
+++ b/examples/frr/pim/assert/rtr3/etc.frr/frr.conf
@@ -1,0 +1,22 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.1.3/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 10.0.2.3/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+ip pim rp 11.0.1.1 224.1.1.0/24
+
+router ospf
+ ospf router-id 172.16.0.3
+ network 10.0.0.0/16 area 0.0.0.0

--- a/examples/frr/pim/assert/rtr3/etc.frr/vtysh.conf
+++ b/examples/frr/pim/assert/rtr3/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/assert/rtr4/etc.frr/daemons
+++ b/examples/frr/pim/assert/rtr4/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/assert/rtr4/etc.frr/frr.conf
+++ b/examples/frr/pim/assert/rtr4/etc.frr/frr.conf
@@ -1,0 +1,22 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.2.4/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 11.0.4.4/24
+ ip pim
+ ip pim passive
+ ip igmp
+
+ip pim rp 11.0.1.1 224.1.1.0/24
+
+router ospf
+ ospf router-id 172.16.0.4
+ network 10.0.0.0/16 area 0.0.0.0
+ redistribute connected

--- a/examples/frr/pim/assert/rtr4/etc.frr/vtysh.conf
+++ b/examples/frr/pim/assert/rtr4/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/spt-switchover/README.md
+++ b/examples/frr/pim/spt-switchover/README.md
@@ -1,0 +1,38 @@
+PIM Shortest Path Tree Switchover Simulation
+============================================
+
+This simulation demonstrates the configuration of Multicast via PIM and IGMP in
+FRRouting through Munet. Due to the network's structure, a Shortest Path Tree
+Switchover (SPT Switchover) will occur. The network also utilizes OSPF to
+populate all routing tables.
+
+```
+   +------+                                              +------+
+   | src- | <-- Source of 224.1.1.1                      | rec- |
+   | rtr1 |                                              | rtr5 |
+   |      |                   (*, 224.1.1.1) Member -->  |      |
+   +--+---+                                              +--+---+
+      |.10                                                  |.10
+      |                                                     |
+      | 11.0.1.0/24                                         | 11.0.5.0/24
+      | local-rtr1                                          | local-rtr5
+      |                                                     |
+      |.1                                                   |.5
+   +--+---+                   +------+                   +--+---+
+   |      |    10.0.6.0/24    |      |    10.0.5.0/24    |      |
+   | rtr1 +-------------------+ rtr6 +-------------------+ rtr5 |
+   |      |.1     net6      .6|      |.6     net5      .5|      |
+   +--+---+                   +------+                   +--+---+
+      |.1                                                   |.5
+      |                                                     |
+      | 10.0.1.0/24                                         | 10.0.4.0/24
+      | net1            Route through RP is pruned!         | net4
+      |                          |                          |
+      |.2                        V                          |.4
+   +--+---+                   +------+                   +--+---+
+   |      |    10.0.2.0/24    |      |    10.0.3.0/24    |      |
+   | rtr2 +-------------------+ rtr3 +-------------------+ rtr4 |
+   |      |.2     net2      .3| (RP) |.3     net3      .4|      |
+   +------+                   +------+                   +------+
+
+```

--- a/examples/frr/pim/spt-switchover/munet.yaml
+++ b/examples/frr/pim/spt-switchover/munet.yaml
@@ -1,0 +1,93 @@
+version: 1
+kinds:
+  - name: frr
+    cmd: |
+      chown frr:frr -R /var/run/frr
+      chown frr:frr -R /var/log/frr
+      /usr/lib/frr/frrinit.sh start
+      tail -F /var/log/frr/frr.log
+    cleanup-cmd: |
+      /usr/lib/frr/frrinit.sh stop
+    volumes:
+      - "./%NAME%/etc.frr:/etc/frr"
+      - "%RUNDIR%/var.log.frr:/var/log/frr"
+      - "%RUNDIR%/var.run.frr:/var/run/frr"
+    cap-add:
+      - SYS_ADMIN
+      - AUDIT_WRITE
+    merge: ["volumes"]
+
+topology:
+  networks:
+    - name: net1
+      ip: 10.0.1.254/24
+    - name: net2
+      ip: 10.0.2.254/24
+    - name: net3
+      ip: 10.0.3.254/24
+    - name: net4
+      ip: 10.0.4.254/24
+    - name: net5
+      ip: 10.0.5.254/24
+    - name: net6
+      ip: 10.0.6.254/24
+    - name: local-rtr5
+      ip: 11.0.5.254/24
+    - name: local-rtr1
+      ip: 11.0.1.254/24
+  nodes:
+    - name: rtr1
+      kind: frr
+      connections:
+        - to: "net1"
+        - to: "net6"
+        - to: "local-rtr1"
+    - name: src-rtr1
+      connections:
+        - to: "local-rtr1"
+      cmd: |
+        ip address add 11.0.1.10/24 dev eth0
+        ip route add default via 11.0.1.1
+        ping 224.1.1.1 -t 128
+    - name: rtr2
+      kind: frr
+      connections:
+        - to: "net1"
+        - to: "net2"
+    - name: rtr3
+      kind: frr
+      connections:
+        - to: "net2"
+        - to: "net3"
+    - name: rtr4
+      kind: frr
+      connections:
+        - to: "net3"
+        - to: "net4"
+    - name: rtr5
+      kind: frr
+      connections:
+        - to: "net4"
+        - to: "net5"
+        - to: "local-rtr5"
+    - name: rec-rtr5
+      kind: frr
+      connections:
+        - to: "local-rtr5"
+    - name: rtr6
+      kind: frr
+      connections:
+        - to: "net5"
+        - to: "net6"
+cli:
+  commands:
+    - name: ""
+      exec: "vtysh -c '{}'"
+      format: "[ROUTER ...] COMMAND"
+      help: "execute vtysh COMMAND on the router[s]"
+      kinds: ["frr"]
+    - name: "vtysh"
+      exec: "/usr/bin/vtysh"
+      format: "vtysh ROUTER [ROUTER ...]"
+      new-window: true
+      kinds: ["frr"]

--- a/examples/frr/pim/spt-switchover/rec-rtr5/etc.frr/daemons
+++ b/examples/frr/pim/spt-switchover/rec-rtr5/etc.frr/daemons
@@ -1,0 +1,7 @@
+zebra=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/spt-switchover/rec-rtr5/etc.frr/frr.conf
+++ b/examples/frr/pim/spt-switchover/rec-rtr5/etc.frr/frr.conf
@@ -1,0 +1,9 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+ip route 0.0.0.0/0 11.0.5.5 eth0
+
+interface eth0
+ ip address 11.0.5.10/24
+ ip igmp
+ ip igmp join 224.1.1.1

--- a/examples/frr/pim/spt-switchover/rec-rtr5/etc.frr/vtysh.conf
+++ b/examples/frr/pim/spt-switchover/rec-rtr5/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/spt-switchover/rtr1/etc.frr/daemons
+++ b/examples/frr/pim/spt-switchover/rtr1/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/spt-switchover/rtr1/etc.frr/frr.conf
+++ b/examples/frr/pim/spt-switchover/rtr1/etc.frr/frr.conf
@@ -1,0 +1,29 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.1.1/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 10.0.6.1/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth2
+ ip address 11.0.1.1/24
+ ip pim
+ ip pim passive
+ ip igmp
+
+ip pim rp 10.0.2.3 224.1.1.0/24
+
+router ospf
+ ospf router-id 172.16.0.1
+ network 10.0.0.0/16 area 0.0.0.0
+ redistribute connected

--- a/examples/frr/pim/spt-switchover/rtr1/etc.frr/vtysh.conf
+++ b/examples/frr/pim/spt-switchover/rtr1/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/spt-switchover/rtr2/etc.frr/daemons
+++ b/examples/frr/pim/spt-switchover/rtr2/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/spt-switchover/rtr2/etc.frr/frr.conf
+++ b/examples/frr/pim/spt-switchover/rtr2/etc.frr/frr.conf
@@ -1,0 +1,22 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.1.2/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 10.0.2.2/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+ip pim rp 10.0.2.3 224.1.1.0/24
+
+router ospf
+ ospf router-id 172.16.0.2
+ network 10.0.0.0/16 area 0.0.0.0

--- a/examples/frr/pim/spt-switchover/rtr2/etc.frr/vtysh.conf
+++ b/examples/frr/pim/spt-switchover/rtr2/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/spt-switchover/rtr3/etc.frr/daemons
+++ b/examples/frr/pim/spt-switchover/rtr3/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/spt-switchover/rtr3/etc.frr/frr.conf
+++ b/examples/frr/pim/spt-switchover/rtr3/etc.frr/frr.conf
@@ -1,0 +1,22 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.2.3/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 10.0.3.3/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+ip pim rp 10.0.2.3 224.1.1.0/24
+
+router ospf
+ ospf router-id 172.16.0.3
+ network 10.0.0.0/16 area 0.0.0.0

--- a/examples/frr/pim/spt-switchover/rtr3/etc.frr/vtysh.conf
+++ b/examples/frr/pim/spt-switchover/rtr3/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/spt-switchover/rtr4/etc.frr/daemons
+++ b/examples/frr/pim/spt-switchover/rtr4/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/spt-switchover/rtr4/etc.frr/frr.conf
+++ b/examples/frr/pim/spt-switchover/rtr4/etc.frr/frr.conf
@@ -1,0 +1,22 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.3.4/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth0
+ ip address 10.0.4.4/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+ip pim rp 10.0.2.3 224.1.1.0/24
+
+router ospf
+ ospf router-id 172.16.0.4
+ network 10.0.0.0/16 area 0.0.0.0

--- a/examples/frr/pim/spt-switchover/rtr4/etc.frr/vtysh.conf
+++ b/examples/frr/pim/spt-switchover/rtr4/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/spt-switchover/rtr5/etc.frr/daemons
+++ b/examples/frr/pim/spt-switchover/rtr5/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/spt-switchover/rtr5/etc.frr/frr.conf
+++ b/examples/frr/pim/spt-switchover/rtr5/etc.frr/frr.conf
@@ -1,0 +1,28 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.4.5/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 10.0.5.5/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth2
+ ip address 11.0.5.1/24
+ ip pim
+ ip pim passive
+ ip igmp
+
+ip pim rp 10.0.2.3 224.1.1.0/24
+
+router ospf
+ ospf router-id 172.16.0.5
+ network 10.0.0.0/16 area 0.0.0.0

--- a/examples/frr/pim/spt-switchover/rtr5/etc.frr/vtysh.conf
+++ b/examples/frr/pim/spt-switchover/rtr5/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/spt-switchover/rtr6/etc.frr/daemons
+++ b/examples/frr/pim/spt-switchover/rtr6/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/spt-switchover/rtr6/etc.frr/frr.conf
+++ b/examples/frr/pim/spt-switchover/rtr6/etc.frr/frr.conf
@@ -1,0 +1,22 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.5.6/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 10.0.6.6/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+ip pim rp 10.0.2.3 224.1.1.0/24
+
+router ospf
+ ospf router-id 172.16.0.6
+ network 10.0.0.0/16 area 0.0.0.0

--- a/examples/frr/pim/spt-switchover/rtr6/etc.frr/vtysh.conf
+++ b/examples/frr/pim/spt-switchover/rtr6/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/ssm/README.md
+++ b/examples/frr/pim/ssm/README.md
@@ -1,0 +1,50 @@
+Source-Specific Multicast (SSM) Simulation
+==========================================
+
+This simulation demonstrates the configuration of source-speficic Multicast via
+PIM-SSM and IGMP in FRRouting through Munet. The network also utilizes OSPF to
+populate all all routing tables.
+
+```
+
+   +------+                                              +------+
+   | src- | <-- Source of 232.1.1.1                      | rec- |
+   | rtr1 |                                              | rtr3 |
+   |      |           (11.0.1.10, 232.1.1.1) Member -->  |      |
+   +--+---+                                              +--+---+
+      |.10                                                  |.10
+      |                                                     |
+      | 11.0.1.0/24                                         | 11.0.3.0/24
+      | local-rtr1                                          | local-rtr3
+      |                                                     |
+      |.1                                                   |.3
+   +--+---+                                              +--+---+
+   |      |   10.0.1.0/24                  10.0.2.0/24   |      |
+   | rtr1 +----------------\            /----------------+ rtr3 |
+   |      |.1    net1       \          /      net2     .3|      |
+   +------+                  \.2      /.2                +------+
+                              +------+
+                              |      |
+                              | rtr2 |
+                              |      |
+                              +--+---+
+   +------+                  /.2 |.2  \.2                +------+
+   |      |   10.0.5.0/24   /    |     \   10.0.3.0/24   |      |
+   | rtr6 + ---------------/     |      \----------------+ rtr4 |
+   |      |.6    net5            |            net3     .4|      |
+   +--+---+                      |                       +--+---+
+      |.6                        | 10.0.5.0/24              |.4
+      |                          | net4                     |
+      | 11.0.6.0/24              |                          | 11.0.4.0/24
+      | local-rtr6               |.5                        | local-rtr4
+      |                       +--+---+                      |
+      |.10                    |      |                      |.10
+   +--+---+                   | rtr5 |                   +--+---+
+   | src- |                   |      |                   | rec- |
+   | rtr6 |                   +------+                   | rtr4 |
+   |      | <--                                          |      |
+   +------+    \       (11.0.6.10, 232.1.1.1) Member --> +------+
+                \
+                 -- Source of 232.1.1.1
+
+```

--- a/examples/frr/pim/ssm/munet.yaml
+++ b/examples/frr/pim/ssm/munet.yaml
@@ -1,0 +1,106 @@
+version: 1
+kinds:
+  - name: frr
+    cmd: |
+      chown frr:frr -R /var/run/frr
+      chown frr:frr -R /var/log/frr
+      /usr/lib/frr/frrinit.sh start
+      tail -F /var/log/frr/frr.log
+    cleanup-cmd: |
+      /usr/lib/frr/frrinit.sh stop
+    volumes:
+      - "./%NAME%/etc.frr:/etc/frr"
+      - "%RUNDIR%/var.log.frr:/var/log/frr"
+      - "%RUNDIR%/var.run.frr:/var/run/frr"
+    cap-add:
+      - SYS_ADMIN
+      - AUDIT_WRITE
+    merge: ["volumes"]
+
+topology:
+  networks:
+    - name: net1
+      ip: 10.0.1.254/24
+    - name: net2
+      ip: 10.0.2.254/24
+    - name: net3
+      ip: 10.0.3.254/24
+    - name: net4
+      ip: 10.0.4.254/24
+    - name: net5
+      ip: 10.0.5.254/24
+    - name: local-rtr3
+      ip: 11.0.3.254/24
+    - name: local-rtr4
+      ip: 11.0.4.254/24
+    - name: local-rtr1
+      ip: 11.0.1.254/24
+    - name: local-rtr6
+      ip: 11.0.6.254/24
+  nodes:
+    - name: rtr1
+      kind: frr
+      connections:
+        - to: "net1"
+        - to: "local-rtr1"
+    - name: src-rtr1
+      connections:
+        - to: "local-rtr1"
+      cmd: |
+        ip address add 11.0.1.10/24 dev eth0
+        ip route add default via 11.0.1.1
+        ping 232.1.1.1 -t 128
+    - name: rtr2
+      kind: frr
+      connections:
+        - to: "net1"
+        - to: "net2"
+        - to: "net3"
+        - to: "net4"
+        - to: "net5"
+    - name: rtr3
+      kind: frr
+      connections:
+        - to: "net2"
+        - to: "local-rtr3"
+    - name: rec-rtr3
+      kind: frr
+      connections:
+        - to: "local-rtr3"
+    - name: rtr4
+      kind: frr
+      connections:
+        - to: "net3"
+        - to: "local-rtr4"
+    - name: rec-rtr4
+      kind: frr
+      connections:
+        - to: "local-rtr4"
+    - name: rtr5
+      kind: frr
+      connections:
+        - to: "net4"
+    - name: rtr6
+      kind: frr
+      connections:
+        - to: "net5"
+        - to: "local-rtr6"
+    - name: src-rtr6
+      connections:
+        - to: "local-rtr6"
+      cmd: |
+        ip address add 11.0.6.10/24 dev eth0
+        ip route add default via 11.0.6.6
+        ping 232.1.1.1 -t 128
+cli:
+  commands:
+    - name: ""
+      exec: "vtysh -c '{}'"
+      format: "[ROUTER ...] COMMAND"
+      help: "execute vtysh COMMAND on the router[s]"
+      kinds: ["frr"]
+    - name: "vtysh"
+      exec: "/usr/bin/vtysh"
+      format: "vtysh ROUTER [ROUTER ...]"
+      new-window: true
+      kinds: ["frr"]

--- a/examples/frr/pim/ssm/rec-rtr3/etc.frr/daemons
+++ b/examples/frr/pim/ssm/rec-rtr3/etc.frr/daemons
@@ -1,0 +1,7 @@
+zebra=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/ssm/rec-rtr3/etc.frr/frr.conf
+++ b/examples/frr/pim/ssm/rec-rtr3/etc.frr/frr.conf
@@ -1,0 +1,9 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+ip route 0.0.0.0/0 11.0.3.3 eth0
+
+interface eth0
+ ip address 11.0.3.10/24
+ ip igmp
+ ip igmp join 232.1.1.1 11.0.1.10

--- a/examples/frr/pim/ssm/rec-rtr3/etc.frr/vtysh.conf
+++ b/examples/frr/pim/ssm/rec-rtr3/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/ssm/rec-rtr4/etc.frr/daemons
+++ b/examples/frr/pim/ssm/rec-rtr4/etc.frr/daemons
@@ -1,0 +1,7 @@
+zebra=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/ssm/rec-rtr4/etc.frr/frr.conf
+++ b/examples/frr/pim/ssm/rec-rtr4/etc.frr/frr.conf
@@ -1,0 +1,9 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+ip route 0.0.0.0/0 11.0.4.4 eth0
+
+interface eth0
+ ip address 11.0.4.10/24
+ ip igmp
+ ip igmp join 232.1.1.1 11.0.6.10

--- a/examples/frr/pim/ssm/rec-rtr4/etc.frr/vtysh.conf
+++ b/examples/frr/pim/ssm/rec-rtr4/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/ssm/rtr1/etc.frr/daemons
+++ b/examples/frr/pim/ssm/rtr1/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/ssm/rtr1/etc.frr/frr.conf
+++ b/examples/frr/pim/ssm/rtr1/etc.frr/frr.conf
@@ -1,0 +1,20 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.1.1/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 11.0.1.1/24
+ ip pim
+ ip pim passive
+ ip igmp
+
+router ospf
+ ospf router-id 172.16.0.1
+ network 10.0.0.0/16 area 0.0.0.0
+ redistribute connected

--- a/examples/frr/pim/ssm/rtr1/etc.frr/vtysh.conf
+++ b/examples/frr/pim/ssm/rtr1/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/ssm/rtr2/etc.frr/daemons
+++ b/examples/frr/pim/ssm/rtr2/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/ssm/rtr2/etc.frr/frr.conf
+++ b/examples/frr/pim/ssm/rtr2/etc.frr/frr.conf
@@ -1,0 +1,41 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.1.2/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 10.0.2.2/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth2
+ ip address 10.0.3.2/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth3
+ ip address 10.0.4.2/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth4
+ ip address 10.0.5.2/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+router ospf
+ ospf router-id 172.16.0.2
+ network 10.0.0.0/16 area 0.0.0.0

--- a/examples/frr/pim/ssm/rtr2/etc.frr/vtysh.conf
+++ b/examples/frr/pim/ssm/rtr2/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/ssm/rtr3/etc.frr/daemons
+++ b/examples/frr/pim/ssm/rtr3/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/ssm/rtr3/etc.frr/frr.conf
+++ b/examples/frr/pim/ssm/rtr3/etc.frr/frr.conf
@@ -1,0 +1,20 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.2.3/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 11.0.3.3/24
+ ip pim
+ ip pim passive
+ ip igmp
+
+router ospf
+ ospf router-id 172.16.0.3
+ network 10.0.0.0/16 area 0.0.0.0
+ redistribute connected

--- a/examples/frr/pim/ssm/rtr3/etc.frr/vtysh.conf
+++ b/examples/frr/pim/ssm/rtr3/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/ssm/rtr4/etc.frr/daemons
+++ b/examples/frr/pim/ssm/rtr4/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/ssm/rtr4/etc.frr/frr.conf
+++ b/examples/frr/pim/ssm/rtr4/etc.frr/frr.conf
@@ -1,0 +1,20 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.3.4/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 11.0.4.4/24
+ ip pim
+ ip pim passive
+ ip igmp
+
+router ospf
+ ospf router-id 172.16.0.4
+ network 10.0.0.0/16 area 0.0.0.0
+ redistribute connected

--- a/examples/frr/pim/ssm/rtr4/etc.frr/vtysh.conf
+++ b/examples/frr/pim/ssm/rtr4/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/ssm/rtr5/etc.frr/daemons
+++ b/examples/frr/pim/ssm/rtr5/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/ssm/rtr5/etc.frr/frr.conf
+++ b/examples/frr/pim/ssm/rtr5/etc.frr/frr.conf
@@ -1,0 +1,13 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.4.5/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+router ospf
+ ospf router-id 172.16.0.5
+ network 10.0.0.0/16 area 0.0.0.0

--- a/examples/frr/pim/ssm/rtr5/etc.frr/vtysh.conf
+++ b/examples/frr/pim/ssm/rtr5/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/examples/frr/pim/ssm/rtr6/etc.frr/daemons
+++ b/examples/frr/pim/ssm/rtr6/etc.frr/daemons
@@ -1,0 +1,9 @@
+zebra=1
+ospfd=1
+pimd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra_options="-d -F traditional --log=file:/var/log/frr/zebra.log"
+ospfd_options="-d -F traditional --log=file:/var/log/frr/ospfd.log"
+pimd_options="-d -F traditional --log=file:/var/log/frr/pimd.log"
+staticd_options="-d -F traditional --log=file:/var/log/frr/staticd.log"

--- a/examples/frr/pim/ssm/rtr6/etc.frr/frr.conf
+++ b/examples/frr/pim/ssm/rtr6/etc.frr/frr.conf
@@ -1,0 +1,20 @@
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+
+interface eth0
+ ip address 10.0.5.6/24
+ ip pim
+ ip igmp
+ ip ospf dead-interval 16
+ ip ospf hello-interval 4
+
+interface eth1
+ ip address 11.0.6.6/24
+ ip pim
+ ip pim passive
+ ip igmp
+
+router ospf
+ ospf router-id 172.16.0.6
+ network 10.0.0.0/16 area 0.0.0.0
+ redistribute connected

--- a/examples/frr/pim/ssm/rtr6/etc.frr/vtysh.conf
+++ b/examples/frr/pim/ssm/rtr6/etc.frr/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config


### PR DESCRIPTION
This adds new example topologies involving PIM-SM and IGMP, both of which I learned more about this summer.