### PR TITLE
mutest: new output arg for out-of-order cmd execution

### DIFF
--- a/munet/base.py
+++ b/munet/base.py
@@ -940,7 +940,15 @@ class Commander:  # pylint: disable=R0904
                 raise CalledProcessError(rc, ac, o, e)
         return rc, o, e
 
-    def _cmd_status(self, cmds, raises=False, warn=True, stdin=None, **kwargs):
+    def _cmd_status(
+        self,
+        cmds,
+        raises=False,
+        warn=True,
+        stdin=None,
+        output=True,
+        **kwargs
+    ):
         """Execute a command."""
         timeout = None
         if "timeout" in kwargs:
@@ -949,7 +957,11 @@ class Commander:  # pylint: disable=R0904
 
         pinput, stdin = Commander._cmd_status_input(stdin)
         p, actual_cmd = self._popen("cmd_status", cmds, stdin=stdin, **kwargs)
-        o, e = p.communicate(pinput, timeout=timeout)
+        if output:
+            o, e = p.communicate(pinput, timeout=timeout)
+        else:
+            o = ''
+            e = ''
         return self._cmd_status_finish(p, cmds, actual_cmd, o, e, raises, warn)
 
     async def _async_cmd_status(

--- a/munet/mutest/userapi.py
+++ b/munet/mutest/userapi.py
@@ -431,6 +431,7 @@ class TestCase:
         self,
         target: str,
         cmd: str,
+        **kwargs,
     ) -> str:
         """Execute a ``cmd`` and return result.
 
@@ -439,7 +440,7 @@ class TestCase:
             cmd: string to execut on the target.
         """
         out = self.targets[target].cmd_nostatus(
-            cmd, stdin=subprocess.DEVNULL, warn=False
+            cmd, stdin=subprocess.DEVNULL, warn=False, **kwargs
         )
         self.last = out = out.rstrip()
         report = out if out else "<no output>"
@@ -742,20 +743,26 @@ class TestCase:
         self.oplogf("   section setting __in_section to True")
         self.__print_header(self.info.tag, desc, add_nl)
 
-    def step(self, target: str, cmd: str) -> str:
+    def step(
+        self,
+        target: str,
+        cmd: str,
+        output: bool = True,
+    ) -> str:
         """See :py:func:`~munet.mutest.userapi.step`.
 
         :meta private:
         """
         self.logf(
-            "#%s.%s:%s:STEP:%s:%s",
+            "#%s.%s:%s:STEP:%s:%s:%s",
             self.tag,
             self.steps + 1,
             self.info.path,
             target,
             cmd,
+            output,
         )
-        return self._command(target, cmd)
+        return self._command(target, cmd, output=output)
 
     def step_json(self, target: str, cmd: str) -> Union[list, dict]:
         """See :py:func:`~munet.mutest.userapi.step_json`.
@@ -1007,17 +1014,18 @@ def get_target(name: str) -> Commander:
     return TestCase.g_tc.targets[name]
 
 
-def step(target: str, cmd: str) -> str:
+def step(target: str, cmd: str, output: bool = True) -> str:
     """Execute a ``cmd`` on a ``target`` and return the output.
 
     Args:
         target: the target to execute the ``cmd`` on.
         cmd: string to execute on the target.
+        output: if False, then DO NOT wait for output. Otherwise waits for ``cmd`` completion.
 
     Returns:
         Returns the ``str`` output of the ``cmd``.
     """
-    return TestCase.g_tc.step(target, cmd)
+    return TestCase.g_tc.step(target, cmd, output)
 
 
 def step_json(target: str, cmd: str) -> Union[list, dict]:

--- a/tests/mutest/mutest_step.py
+++ b/tests/mutest/mutest_step.py
@@ -1,0 +1,9 @@
+"""Test that out-of-order cmd execution is supported by step"""
+from munet.mutest.userapi import wait_step, section, step
+
+section("Test the no-output arg in step")
+
+step('r1', 'touch test-file1; sleep 1; mv test-file1 test-file2', output=False)
+
+wait_step('r1', 'ls', 'test-file1', 'Saw test-file1',  2, 0.1)
+wait_step('r1', 'ls', 'test-file2', 'Saw test-file2',  2, 0.1)


### PR DESCRIPTION
Adds a new argument, `output: bool`, for the mutest method `step()` that allows for a `cmd` to be executed within a node without waiting for any output. This introduces the ability to effectively run a series of (possibly lengthy) commands in the background while the mutest is allowed to continue executing further steps (some of which may require a previous command to still be in the middle of executing).

This commit also modifies `_cmd_status()` in base.py to support executing a command without returning output in the first place.