### PR TITLE
mutest: print pause on empty desc

### DIFF
--- a/munet/mutest/__main__.py
+++ b/munet/mutest/__main__.py
@@ -237,6 +237,10 @@ async def execute_test(
     try:
         passed, failed, e = tc.execute()
     except uapi.CLIOnErrorError as error:
+        if error.desc != "":
+            print(f"\n== CLI ON ERROR: {error.desc} ==")
+        else:
+            print("\n== CLI ON ERROR: *NO DESCRIPTION PROVIDED* ==")
         await async_cli(unet)
         passed, failed, e = 0, 0, error
 

--- a/munet/mutest/userapi.py
+++ b/munet/mutest/userapi.py
@@ -85,6 +85,8 @@ class ScriptError(Exception):
 
 class CLIOnErrorError(Exception):
     """Enter CLI after error."""
+    def __init__(self, desc=""):
+        self.desc = desc
 
 
 def pause_test(desc=""):
@@ -97,6 +99,8 @@ def pause_test(desc=""):
     while True:
         if desc:
             print(f"\n== PAUSING: {desc} ==")
+        else:
+            print("\n== PAUSING: *NO DESCRIPTION PROVIDED* ==")
         try:
             user = input('PAUSED, "cli" for CLI, "pdb" to debug, "Enter" to continue: ')
         except EOFError:
@@ -119,7 +123,7 @@ def act_on_result(success, args, desc=""):
     elif success:
         return
     if args.cli_on_error:
-        raise CLIOnErrorError()
+        raise CLIOnErrorError(desc)
     if args.pause_on_error:
         pause_test(desc)
 


### PR DESCRIPTION
Pausing on a hidden step causes confusion in large mutest sequences. This commit prevents pausing if the step desc is an empty string.

EDIT: This PR has been updated such that it will continue to stop on steps without a description. For each instance of this, an explicit message will be printed to the console (which was previously missing.)