### PR TITLE
docs: update docs with env vars

### DIFF
--- a/README.org
+++ b/README.org
@@ -218,14 +218,16 @@ of ~10.0.0.2~.
 
 #+begin_src yaml
   topology:
-  networks-autonumber: true
-  networks:
-    - name: net0
-  nodes:
-    - name: h1
-      connections: ["net0"]
-    - name: h2
-      connections: ["net0"]
+    networks-autonumber: true
+    networks:
+      - name: net0
+    nodes:
+      - name: h1
+        connections:
+          - to: net0
+      - name: h2
+        connections:
+          - to: net0
 #+end_src
 
 *** Router VM
@@ -242,24 +244,24 @@ cisco VM using a nexos file system image.
 
 #+begin_src yaml
   topology:
-  networks-autonumber: true
-  dns-network: "mgmt0"
-  networks:
-    - name: mgmt0
-      ip: 192.168.0.254/24
-      nat: true
-    - name: net0
-  nodes:
-    # ...
-    - name: r1
-      kind: cisco
-      connections:
-        - to: "mgmt0"
-          name: "eth1"
-          driver: "e1000"
-        - to: "net0"
-          name: "eth2"
-          driver: "e1000"
+    networks-autonumber: true
+    dns-network: "mgmt0"
+    networks:
+      - name: mgmt0
+        ip: 192.168.0.254/24
+        nat: true
+      - name: net0
+    nodes:
+      # ...
+      - name: r1
+        kind: cisco
+        connections:
+          - to: "mgmt0"
+            name: "eth1"
+            driver: "e1000"
+          - to: "net0"
+            name: "eth2"
+            driver: "e1000"
   kinds:
     - name: cisco
       shell: false

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -35,6 +35,34 @@ configuration.
     mounting runtime directories (e.g., log directories) in the node namespace.
 
 
+Environment Variables
+^^^^^^^^^^^^^^^^^^^^^
+
+Enviornment variables will additionally be made available to any command executed
+within a munet node or interactive terminal opened within a munet node. These
+variables should not be overwritten since they may be used to assist munet in
+cleaning up.
+
+  ``MUNET_PID``
+    The PID of the parent munet process.
+
+  ``MUNET_NODENAME``
+    The name of the target munet node.
+
+Some extra variables are also set *only* in interactive terminals to make
+availible the same variables present within the regular munet config. (i.e.
+see the start of the ``Variables`` section.)
+
+  ``RUNDIR``
+    Same as ``%RUNDIR%``.
+
+  ``NODENAME``
+    Same as ``%NAME%``.
+
+  ``CONFIGDIR``
+    Same as ``%CONFIGDIR%``.
+
+
 Topology
 --------
 


### PR DESCRIPTION
There was a request for the set environment variables to be detailed in the doc, so I've added such to the configuration page.

There are also two fixes to the examples present within the munet README.org, including incorrect indenting and a bad declaration of connections using yaml's flow-style sequences. (i.e. flow-style sequence declaration worked in the past when declaring the connections but no longer seems to work, leaving the example inaccurate)