### PR TITLE
mutest: uncap step in formatter

### DIFF
--- a/munet/mutest/userapi.py
+++ b/munet/mutest/userapi.py
@@ -180,7 +180,7 @@ class TestCase:
 
     # sum_hfmt = "{:5.5s} {:4.4s} {:>6.6s} {}"
     # sum_dfmt = "{:5s} {:4.4s} {:^6.6s} {}"
-    sum_fmt = "%-8.8s %4.4s %{}s %6s  %s"
+    sum_fmt = "%-8s %4.4s %{}s %6s  %s"
 
     def __init__(
         self,


### PR DESCRIPTION
If the step number string exceeds 8 characters (e.g. "`1.1.2.122`"), do not cut off the end of the step string (e.g. would print "`1.1.2.12`"). Instead, allow it to print fully.