### PR TITLE
munet: fix bug in cli.py

### DIFF
--- a/munet/cli.py
+++ b/munet/cli.py
@@ -182,9 +182,7 @@ def host_cmd_split(unet, line, toplevel):
     if not csplit:
         return hosts, "", "", True
 
-    i = line.index(csplit[0])
-    i += len(csplit[0])
-    return hosts, csplit[0], line[i:].strip(), banner
+    return hosts, csplit[0], ' '.join(csplit[1:]), banner
 
 
 def win_cmd_host_split(unet, cmd, kinds, defall):


### PR DESCRIPTION
When a target node and command share the same same substring in host_cmd_split, then an incorrect index will be used. This results in returning a bad command.

For example, define the following in munet.yaml:
```
topology:
  nodes:
    - name: shoo
    - name: foo
cmd:
  commands:
    - name: ""
      exec: "bash -c \"{}\""
      format: "[NODE ...] COMMAND [ARGUMENT ...]"
      interactive: true
```

and the following results can be observed:
```
munet> foo sh echo hi
hi
munet> shoo sh echo hi
*** non-zero exit status: 127
/bin/bash: line 1: oo: command not found
munet>
```