### PR TITLE
fix partial match for non dictionary items

### DIFF
--- a/munet/mutest/userapi.py
+++ b/munet/mutest/userapi.py
@@ -579,8 +579,7 @@ class TestCase:
             if (new_items := json_diff.get("iterable_item_added")) is not None:
                 new_item_paths = list(new_items.keys())
                 for path in new_item_paths:
-                    if type(new_items[path]) is dict:
-                        del new_items[path]
+                    del new_items[path]
                 if len(new_items) == 0:
                     del json_diff["iterable_item_added"]
 

--- a/tests/mutest/mutest_matchwait_json.py
+++ b/tests/mutest/mutest_matchwait_json.py
@@ -242,11 +242,10 @@ _, ret = match_step_json(
     "r1",
     f"echo '{json2}'",
     json1,
-    "Data in different arrays don't match",
-    expect_fail=True,
+    "Data in one array is a subset of another"
 )
 test_step(
-    ret == {'iterable_item_added': {'root[1]': 'bar'}},
+    ret == ['foo', 'bar'],
     "    Correct return value",
 )
 _, ret = match_step_json(
@@ -300,11 +299,10 @@ _, ret = match_step_json(
     "r1",
     f"echo '{json4}'",
     json1,
-    "Data in different arrays don't match (nested)",
-    expect_fail=True
+    "Data in one array is a subset of another"
 )
 test_step(
-    ret == {'iterable_item_added': {"root['level1'][1]['level3'][1]": 'l4'}},
+    ret == {"level1": ["level2", {"level3": ["level4", "l4"]}]},
     "    Correct return value",
 )
 match_step_json(


### PR DESCRIPTION
currenlty with partial match `[{"foo":"foo"}]` is considered a subset of `[{"foo":"foo"}, {"bar":"bar"}]`. However `[1]` is not considered a subset of `[1,2]`. This fixes the behavior so that partial match rules apply to non dictionary items within a list.