### PR TITLE
munet: Configurable environment variables within Linux Namespace nodes

### DIFF
--- a/munet/native.py
+++ b/munet/native.py
@@ -1231,15 +1231,73 @@ ff02::2\tip6-allrouters
 class L3NamespaceNode(L3NodeMixin, LinuxNamespace):
     """A namespace L3 node."""
 
-    def __init__(self, name, pid=True, **kwargs):
+    def __init__(self, name, pid=True, config=None, **kwargs):
         # logging.warning(
         #     "L3NamespaceNode: name %s MRO: %s kwargs %s",
         #     name,
         #     L3NamespaceNode.mro(),
         #     kwargs,
         # )
-        super().__init__(name, pid=pid, **kwargs)
+        self.config = config if config else {}
+        super().__init__(name, pid=pid, config=config, **kwargs)
         super().pytest_hook_open_shell()
+
+    def _get_sub_args(self, cmd_list, defaults, use_pty=False, ns_only=False, **kwargs):
+        """Returns pre-command, cmd, and default keyword args.
+
+        Overrides Commander in order to insert configured enviornmental variables
+        """
+        pre_cmd_list, cmd_list, defaults = super()._get_sub_args(
+            cmd_list, defaults, use_pty, ns_only, **kwargs
+        )
+
+        if self.config and "env" in self.config and self.config["env"]:
+            config_env = {}
+            for env_var in self.config["env"].items():
+                config_env[env_var[0]] = env_var[1]["value"]
+
+            # All values in defaults should NOT be overwritten by config_env
+            config_env.update(defaults["env"])
+            defaults["env"] = config_env
+
+        return pre_cmd_list, cmd_list, defaults
+
+    def run_in_window(  # pylint: disable=too-many-positional-arguments
+        self,
+        cmd,
+        wait_for=False,
+        background=False,
+        name=None,
+        title=None,
+        forcex=False,
+        new_window=False,
+        tmux_target=None,
+        ns_only=False,
+        env_vars=None,
+    ):
+
+        if self.config and "env" in self.config and self.config["env"]:
+            config_env = {}
+            for env_var in self.config["env"].items():
+                config_env[env_var[0]] = env_var[1]["value"]
+
+            if isinstance(env_vars, dict):
+                # All values in defaults should NOT be overwritten by config_env
+                config_env.update(env_vars)
+            env_vars=config_env
+
+        super().run_in_window(
+            cmd,
+            wait_for,
+            background,
+            name,
+            title,
+            forcex,
+            new_window,
+            tmux_target,
+            ns_only,
+            env_vars,
+        )
 
     async def _async_delete(self):
         self.logger.debug("%s: deleting", self)

--- a/tests/mutest_after/env_vars/munet.yaml
+++ b/tests/mutest_after/env_vars/munet.yaml
@@ -1,0 +1,11 @@
+
+topology:
+  nodes:
+    - name: r1
+      cmd: |
+        echo $foo0
+      env:
+      - name: foo0
+        value: bar
+      - name: foo1
+        value: 'bar ''" baz'

--- a/tests/mutest_after/env_vars/mutest_config_env.py
+++ b/tests/mutest_after/env_vars/mutest_config_env.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# April 18 2025, Liam Brady <lbrady@labn.net>
+#
+# Copyright (c) 2022, LabN Consulting, L.L.C.
+#
+"""Test for config of env variables.
+
+This test is for ensuring that configured environment variables properly appear
+within run commands.
+"""
+import munet
+from munet.mutest.userapi import match_step
+from munet.mutest.userapi import section
+
+# Configured environment variables also should be set within
+# new munet windows, however, this is not tested here.
+
+section("Test config for env variables")
+
+match_step(
+    "r1",
+    "cat cmd.out",
+    "bar",
+    "Check for env variable in cmd.out",
+    exact_match=True,
+)
+match_step(
+    "r1",
+    "echo $foo0",
+    "bar",
+    "Check for env variable in Linux namespace",
+    exact_match=True,
+)
+match_step(
+    "r1",
+    "echo $foo1",
+    "bar '\" baz",
+    "Check env variable for proper quoting",
+    exact_match=True,
+)


### PR DESCRIPTION
Previously, configured env variables would not appear within Linux namespace nodes. This commit adds support for such a capability through the `env` config. e.g:

```
topology:
  nodes:
    - name: r1
      env:
        - name: foo
          value: bar
```

sets the appropriate env variable in both all run commands and in opened windows.

Closes #22 