### PR TITLE
README.org: Improve clarity of install instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ run:
 	sudo -E $(POETRYRUN) python3 -m munet
 
 install:
-	$(POETRY) install
+	$(POETRY) install --all-extras
 
 # ====
 # YANG

--- a/README.org
+++ b/README.org
@@ -333,13 +333,22 @@ with poetry:
   source ~/.poetrybin/bin/activate
   pip install poetry
   pip uninstall keyring
+  deactivate
 #+end_src
 
 NOTE: add "~/.poetrybin/bin" to your $PATH
 
 Install μNET with dependencies:
 
-  poetry install --all-extras
+#+begin_src shell
+  make install
+#+end_src
+
+NOTE: To run munet or mutest locally, you need to enter the poetry virtual enviornment:
+
+#+begin_src shell
+  $(poetry env activate)
+#+end_src
 
 *** Check your install
 


### PR DESCRIPTION
~~Following the munet build instructions in `README.md`, two venvs will be created: one manually in `~/.poetrybin`, and one by poetry in `~/.cache/pypoetry`. `poetry install` will then install dependencies into the former of the two, when `make test` expects mutest to be running in the second (since poetry does not find VIRTUAL_ENV as being set). This results in the failure to run any unit tests on a fresh install from source.~~

~~This commit ensures that VIRTUAL_ENV is always set, so that poetry understands that it is running in an existing venv that it should itself use. This consequentially prevents the second venv from being created, solving any unit testing issues.~~

~~That said, I am unsure if there was a reason why VIRTUAL_ENV was being unset in the first place.~~

Following some clarifications within the discussion, it was understood that VIRTUAL_ENV being unset was intended. However, a lack of clarity within the related and for-developer installation instructions made it easy for mistakes to be made and for `make` or `make check` to fail. Alongside this, two fixes are made within this commit:

1. Explicitely deactivate ~/.poetrybin in order to prevent accidental installs within the venv.

2. Use `make install` instead of calling `poetry install`. This way, if a user is inside a venv, the dependencies get correctly installed to the cached poetry venv, and not the active venv (i.e. because VIRTUAL_ENV is unset).