### PR TITLE
mutest: improve clarity of pause steps

### DIFF
--- a/munet/mutest/userapi.py
+++ b/munet/mutest/userapi.py
@@ -102,7 +102,7 @@ def pause_test(desc=""):
         else:
             print("\n== PAUSING: *NO DESCRIPTION PROVIDED* ==")
         try:
-            user = input('PAUSED, "cli" for CLI, "pdb" to debug, "Enter" to continue: ')
+            user = input('PAUSED, type "cli" for CLI, "pdb" to debug, or press [Enter] to continue: ')
         except EOFError:
             print("^D...continuing")
             break
@@ -111,6 +111,8 @@ def pause_test(desc=""):
             raise CLIOnErrorError()
         if user == "pdb":
             breakpoint()  # pylint: disable=W1515
+        elif user == "Enter" or user == "enter":
+            break
         elif user:
             print(f'Unrecognized input: "{user}"')
         else:


### PR DESCRIPTION
When pausing to choose cli, pdb, or continue, there is a mix of typing and key-pressing that is accepted.

This can result in confusion when 'Enter' does not refer to the string 'Enter', but the keybind. In order to improve clarity, simply accept either input.