### PR TITLE
munet: disallow some p2p links

### DIFF
--- a/munet/native.py
+++ b/munet/native.py
@@ -3110,6 +3110,7 @@ ff02::2\tip6-allrouters
             # p2p link
             assert node1.name in self.hosts
             assert node1.name in self.hosts
+            assert c1 and c2
             isp2p = True
 
         if "name" not in c1:


### PR DESCRIPTION
A p2p links must be configured on both ends. However, `remote-name` allows one node to implicitly create an interface on another node even if the connection is absent in the opposite node's config.

For example, the config as follows:
```
topology:
  networks:
    - name: net1
  nodes:
    - name: r1
      connections:
        - to: r2
          remote-name: ethX
        - to: r2
    - name: r2
      connections:
        - to: r1
```
results in the following observed connections between nodes:
```
________              ________
|      |              |      |
|     eth0 <------> eth1     |
| r1   |              |   r2 |
|     eth1 <------> eth0     |
|______|              |______|

```
Note that the configured `remote-name` value even ends up discarded (`eth0` in r1 connects to `eth1` in r2, and not `ethX`) since the lack of config in r2 causes an interface name to be automatically generated.

Asserting that each endpoint of a p2p link is configured prevents this behavior from occurring.