### PR TITLE
DON'T MERGE: Asynchronous shell_spawn() with removed test case

### DIFF
--- a/munet/base.py
+++ b/munet/base.py
@@ -682,6 +682,12 @@ class Commander:  # pylint: disable=R0904
 
             self.logger.debug("%s: expecting: %s", self, patterns)
 
+            if p.fileno() == -1:
+                # XXX PopenSpawn's lack of file descriptor (p.fileno()) causes error
+                # with expect() only when async_=True is set. Is this an upstream issue?
+                logging.error("pexpect.popen_spawn.PopenSpawn causes asyncio errors")
+                assert False
+
             while index := await p.expect(patterns, async_=True):
                 if trace:
                     assert p.match is not None

--- a/munet/base.py
+++ b/munet/base.py
@@ -603,7 +603,7 @@ class Commander:  # pylint: disable=R0904
             p = pexpect.spawn(actual_cmd[0], actual_cmd[1:], echo=echo, **defaults)
         return p, actual_cmd
 
-    def spawn(
+    async def spawn(
         self,
         cmd,
         spawned_re,
@@ -616,7 +616,7 @@ class Commander:  # pylint: disable=R0904
         trace=None,
         **kwargs,
     ):
-        """Create a spawned send/expect process.
+        """Create an async spawned send/expect process.
 
         Args:
             cmd: list of args to exec/popen with, or an already open socket
@@ -682,7 +682,7 @@ class Commander:  # pylint: disable=R0904
 
             self.logger.debug("%s: expecting: %s", self, patterns)
 
-            while index := p.expect(patterns):
+            while index := await p.expect(patterns, async_=True):
                 if trace:
                     assert p.match is not None
                     self.logger.debug(
@@ -761,7 +761,7 @@ class Commander:  # pylint: disable=R0904
         combined_prompt = r"({}|{})".format(re.escape(PEXPECT_PROMPT), prompt)
 
         assert not is_file_like(cmd) or not use_pty
-        p = self.spawn(
+        p = await self.spawn(
             cmd,
             combined_prompt,
             expects=expects,

--- a/munet/native.py
+++ b/munet/native.py
@@ -911,7 +911,7 @@ ff02::2\tip6-allrouters
         logfile_read = open(lfname, "a+", encoding="utf-8")
         logfile_read.write("-- start read logging for: '{}' --\n".format(sock))
 
-        p = self.spawn(sock, prompt, logfile=logfile, logfile_read=logfile_read)
+        p = await self.spawn(sock, prompt, logfile=logfile, logfile_read=logfile_read)
         from .base import ShellWrapper  # pylint: disable=C0415
 
         p.send("\n")

--- a/tests/control/test_spawn.py
+++ b/tests/control/test_spawn.py
@@ -57,6 +57,8 @@ async def test_spawn(unet_share, host, mode, shellcmd):
     unet = unet_share
     if not os.path.exists(shellcmd):
         pytest.skip(f"{shellcmd} not installed skipping")
+    if host == "remote1" and mode == "piped":
+        pytest.skip("Skipping due to asyncio issues")
 
     os.environ["TEST_SHELL"] = shellcmd
 


### PR DESCRIPTION
DON'T MERGE

This PR contains updates for shell_expect() that makes it async, however, such leads to an upstream pexpect OSError (bad socket descriptor). The specific test cases have been removed in this commit in order to test how much code coverage is lost.