### PR TITLE
munet: replace %NAME% in configured prompts

### DIFF
--- a/README.org
+++ b/README.org
@@ -164,6 +164,7 @@ module: labn-munet-config
   |     |     +--rw user?               string
   |     |     +--rw password?           string
   |     |     +--rw initial-password?   string
+  |     |     +--rw prompt?             string
   |     |     +--rw expects*            string
   |     |     +--rw sends*              string
   |     |     +--rw timeout?            uint32
@@ -720,9 +721,19 @@ munet>
                for the user. Often part of the bring-up process will set a new
                password and that should then be stored in the ../password leaf.";
           }
+          leaf prompt {
+            type string;
+            description
+              "String of expected prompt within the console.
+
+               CONFIG: Only expands %NAME%.";
+          }
           leaf-list expects {
             type string;
-            description "Strings to expect for logging into the console";
+            description
+              "Strings to expect for logging into the console.
+
+               CONFIG: Only expands %NAME%.";
           }
           leaf-list sends {
             type string;
@@ -732,7 +743,9 @@ munet>
                corresponding expect is seen, zero length strings are
                allowed which indicate send nothing. An Expect with a
                send nothing could be used to reset the timeout timer on
-               long boots";
+               long boots.
+
+               CONFIG: Only expands %NAME%.";
           }
           leaf timeout {
             type uint32;

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -16,9 +16,14 @@ found XXX`here`.
 Variables
 ---------
 
-Munet defines a few variables to use within the configuration. The following
-variables are expanded with their dynamic values when reading in the
-configuration.
+Munet defines a few variables for use within both any munet configuration file
+and the enviornment namespaces of any munet node.
+
+Configuration Files
+^^^^^^^^^^^^^^^^^^^
+
+The following variables are expanded with their dynamic values when munet
+interprets the configuration.
 
   ``%CONFIGDIR%``
     Expands to the absolute path to the directory containing the config file.
@@ -34,11 +39,16 @@ configuration.
     the config item this variable is used in. This directory is often useful for
     mounting runtime directories (e.g., log directories) in the node namespace.
 
+.. warning::
+  Some configuration options do not support the full range of configuration
+  variables. In order to determine whether a variable will be expanded or not,
+  please check the config's description within the YANG module definition.
+
 
 Environment Variables
 ^^^^^^^^^^^^^^^^^^^^^
 
-Enviornment variables will additionally be made available to any command executed
+The following enviornment variables are made available to any command executed
 within a munet node or interactive terminal opened within a munet node. These
 variables should not be overwritten since they may be used to assist munet in
 cleaning up.

--- a/munet/munet-schema.json
+++ b/munet/munet-schema.json
@@ -171,6 +171,9 @@
                   "initial-password": {
                     "type": "string"
                   },
+                  "prompt": {
+                    "type": "string"
+                  },
                   "expects": {
                     "type": "array",
                     "items": {
@@ -516,6 +519,9 @@
                         "type": "string"
                       },
                       "initial-password": {
+                        "type": "string"
+                      },
+                      "prompt": {
                         "type": "string"
                       },
                       "expects": {

--- a/munet/native.py
+++ b/munet/native.py
@@ -2673,18 +2673,29 @@ users:
         if self.disk_created:
             password = cc.get("initial-password", password)
 
+        expects=cc.get("expects")
+        if expects is not None:
+            for expect_str in expects:
+                expect_str.replace("%NAME%", str(self.name))
+        sends=cc.get("sends")
+        if sends is not None:
+            for send_str in sends:
+                send_str.replace("%NAME%", str(self.name))
+
         #
         # Connect to the console socket, retrying
         #
         prompt = cc.get("prompt")
+        if prompt is not None:
+            prompt.replace("%NAME%", str(self.name))
         cons = await self._opencons(
             *confiles,
             prompt=prompt,
             is_bourne=not bool(prompt),
             user=cc.get("user", "root"),
             password=password,
-            expects=cc.get("expects"),
-            sends=cc.get("sends"),
+            expects=expects,
+            sends=sends,
             timeout=int(cc.get("timeout", 60)),
         )
         self.conrepl = cons[0]


### PR DESCRIPTION
Some prompts may share a name with the host
node (i.e. a Cisco router may change its host
name.) Therefore, %NAME% should be replaced
within the configured `prompt` for easy
configuration (and applicability to kinds).

`expects` and `sends` have also been changed
to replace %NAME%, and the yang schema
updated to include `prompt` (which was
missing).