### PR TITLE
munet: new `*-file` config

### DIFF
--- a/README.org
+++ b/README.org
@@ -50,6 +50,7 @@ module: labn-munet-config
   |  +--rw cap-add*             string
   |  +--rw cap-remove*          string
   |  +--rw cmd?                 string
+  |  +--rw cmd-file?            string
   |  +--rw cleanup-cmd?         string
   |  +--rw ready-cmd?           string
   |  +--rw image?               string
@@ -67,6 +68,7 @@ module: labn-munet-config
   |  |  +--rw disk-driver?       string
   |  |  +--rw disk-template?     string
   |  |  +--rw initial-cmd?       string
+  |  |  +--rw initial-cmd-file?  string
   |  |  +--rw kernel?            string
   |  |  +--rw initrd?            string
   |  |  +--rw kvm?               boolean
@@ -135,6 +137,7 @@ module: labn-munet-config
   |     +--rw cap-add*             string
   |     +--rw cap-remove*          string
   |     +--rw cmd?                 string
+  |     +--rw cmd-file?            string
   |     +--rw cleanup-cmd?         string
   |     +--rw ready-cmd?           string
   |     +--rw image?               string
@@ -152,6 +155,7 @@ module: labn-munet-config
   |     |  +--rw disk-driver?       string
   |     |  +--rw disk-template?     string
   |     |  +--rw initial-cmd?       string
+  |     |  +--rw initial-cmd-file?  string
   |     |  +--rw kernel?            string
   |     |  +--rw initrd?            string
   |     |  +--rw kvm?               boolean
@@ -555,6 +559,13 @@ munet>
         type string;
         description "Shell command[s] to execute when creating the node.";
       }
+      leaf cmd-file {
+        type string;
+        description
+          "Shell command[s] to execute when creating the node, loaded
+           from the specified file. Takes precedence over `cmd` when
+           both are configured.";
+      }
       leaf cleanup-cmd {
         type string;
         description
@@ -678,6 +689,15 @@ munet>
              template. These commands are run prior to the standard ../../cmd
              when a disk is first created from a disk template";
         }
+        leaf initial-cmd-file {
+          type string;
+          description
+            "Shell command[s] to execute when creating the node from a disk
+             template. These commands are run prior to the standard ../../cmd
+             when a disk is first created from a disk template and are loaded
+             from the specified file. Takes precedence over `initial-cmd` when
+             both are configured.";
+        }
         leaf kernel {
           type string;
           description "path to kernel image (e.g,. bzImage) to boot";
@@ -718,12 +738,12 @@ munet>
           description "Configuration for console handling";
           leaf user {
             type string;
-	    default "root";
+            default "root";
             description "User to login to console with";
           }
           leaf password {
             type string;
-	    default "admin";
+            default "admin";
             description "Password to login to console with";
           }
           leaf initial-password {

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -120,6 +120,7 @@ Tree diagram for node config::
    |     +--rw cap-add*       string
    |     +--rw cap-remove*    string
    |     +--rw cmd?           string
+   |     +--rw cmd-file?      string
    |     +--rw cleanup-cmd?   string
    |     +--rw image?         string
    |     +--rw server?        string
@@ -144,6 +145,28 @@ Tree diagram for node config::
    |     +--rw shell?         union
    |     +--rw volumes*       string
 
+A particularly useful config option for any node is to set the ``cmd``. The
+``cmd`` is a startup command that will run each time when the node is
+started by munet. It can be used to setup the runtime directory,
+automatically run utilities, etc. ::
+
+    topology:
+     nodes:
+       - name: h1
+	 cmd: |
+	   echo "foo" > foo.txt
+	   cat ./foo.txt
+
+The default interpreter for this is ``/bin/bash``, however, separate interpreters
+can be used when ``shell`` is set to the interpreter path (e.g. ``/usr/bin/python3``)
+Alternatively, the ``cmd`` can be treated as basic console input if ``shell`` is set
+to `false`.
+
+When ``cmd-file`` is set to a path, the startup command is instead read from the
+specified file (and the configured ``cmd`` ignored.) A best effort attempt is made
+to use the same interpreter as specified by the file's shebang (again, defaulting
+to ``/bin/bash`` if none is found). Setting ``shell`` overrides this behavior to use
+a specific configured interpreter instead.
 
 Connections
 """""""""""

--- a/munet/munet-schema.json
+++ b/munet/munet-schema.json
@@ -84,6 +84,9 @@
           "cmd": {
             "type": "string"
           },
+          "cmd-file": {
+            "type": "string"
+          },
           "cleanup-cmd": {
             "type": "string"
           },
@@ -133,6 +136,9 @@
                 "type": "string"
               },
               "initial-cmd": {
+                "type": "string"
+              },
+              "initial-cmd-file": {
                 "type": "string"
               },
               "kernel": {
@@ -434,6 +440,9 @@
               "cmd": {
                 "type": "string"
               },
+              "cmd-file": {
+                "type": "string"
+              },
               "cleanup-cmd": {
                 "type": "string"
               },
@@ -483,6 +492,9 @@
                     "type": "string"
                   },
                   "initial-cmd": {
+                    "type": "string"
+                  },
+                  "initial-cmd-file": {
                     "type": "string"
                   },
                   "kernel": {

--- a/munet/native.py
+++ b/munet/native.py
@@ -266,15 +266,26 @@ class NodeMixin:
         commander.cmd_raises(f"rm -rf {self.rundir}")
         commander.cmd_raises(f"mkdir -p {self.rundir}")
 
-    def _shebang_prep(self, config_key):
-        cmd = self.config.get(config_key, "").strip()
+    def _shebang_prep(self, config_key, is_file=False):
+        shell_cmd = "/bin/bash"  # default shell
+        if not is_file:
+            cmd = self.config.get(config_key, "").strip()
+        else:
+            cmd_file = self.config.get(config_key, "").strip()
+            with open(cmd_file, "r", encoding="ascii") as f:
+                lines = f.readlines()
+                # We want to avoid overwriting the shebang if it already exists
+                if lines and lines[0].startswith("#!"):
+                    shell_cmd = lines.pop(0)[2:].strip()
+                cmd = ''.join(lines).strip()
+
         if not cmd:
             return []
 
         script_name = fsafe_name(config_key)
 
         # shell_cmd is a union and can be boolean or string
-        shell_cmd = self.config.get("shell", "/bin/bash")
+        shell_cmd = self.config.get("shell", shell_cmd)
         if not isinstance(shell_cmd, str):
             if shell_cmd:
                 # i.e., "shell: true"
@@ -319,8 +330,8 @@ class NodeMixin:
 
         return cmds
 
-    async def _async_shebang_cmd(self, config_key, warn=True):
-        cmds = self._shebang_prep(config_key)
+    async def _async_shebang_cmd(self, config_key, warn=True, is_file=False):
+        cmds = self._shebang_prep(config_key, is_file)
         if not cmds:
             return 0
 
@@ -341,7 +352,9 @@ class NodeMixin:
         return rc
 
     def has_run_cmd(self) -> bool:
-        return bool(self.config.get("cmd", "").strip())
+        has_cmd = bool(self.config.get("cmd", "").strip())
+        has_cmd_file = bool(self.config.get("cmd-file", "").strip())
+        return has_cmd or has_cmd_file
 
     async def get_proc_child_pid(self, p):
         # commander is right for both unshare inline (our proc pidns)
@@ -376,7 +389,11 @@ class NodeMixin:
             "[rundir %s exists %s]", self.rundir, os.path.exists(self.rundir)
         )
 
-        cmds = self._shebang_prep("cmd")
+        if self.config.get("cmd-file"):
+            cmds = self._shebang_prep("cmd-file", is_file=True)
+        else:
+            cmds = self._shebang_prep("cmd")
+
         if not cmds:
             return
 
@@ -1481,7 +1498,8 @@ class L3ContainerNode(L3NodeMixin, LinuxNamespace):
                     # u'--entrypoint=""',
                     f"--volume={shebang_cmdpath}:/tmp/{script_name}.shebang",
                 ]
-
+        if self.config.get("cmd-file", "").strip():
+            raise NotImplementedError("cmd-file is not yet supported for podman nodes")
         cmd = self.config.get("cmd", "").strip()
 
         # See if we have a custom update for this `kind`
@@ -1901,18 +1919,30 @@ class L3QemuVM(L3NodeMixin, LinuxNamespace):
         if args:
             self.extra_mounts += args
 
-    async def _run_cmd(self, cmd_node):
+    async def _run_cmd(self, cmd_node, is_file=False, in_qemu_conf=False):
         """Run the configured commands for this node inside VM."""
         self.logger.debug(
             "[rundir %s exists %s]", self.rundir, os.path.exists(self.rundir)
         )
 
-        cmd = self.config.get(cmd_node, "").strip()
+        shell_cmd = "/bin/bash"  # default shell
+        if in_qemu_conf:
+            cmd = self.qemu_config.get(cmd_node, "").strip()
+        else:
+            cmd = self.config.get(cmd_node, "").strip()
+        if is_file:
+            with open(cmd, "r", encoding="ascii") as f:
+                lines = f.readlines()
+                # We want to avoid overwriting the shebang if it already exists
+                if lines and lines[0].startswith("#!"):
+                    shell_cmd = lines.pop(0)[2:].strip()
+                cmd = ''.join(lines).strip()
+
         if not cmd:
             self.logger.debug("%s: no `%s` to run", self, cmd_node)
             return None
 
-        shell_cmd = self.config.get("shell", "/bin/bash")
+        shell_cmd = self.config.get("shell", shell_cmd)
         if not isinstance(shell_cmd, str):
             if shell_cmd:
                 shell_cmd = "/bin/bash"
@@ -1984,8 +2014,15 @@ class L3QemuVM(L3NodeMixin, LinuxNamespace):
 
     async def run_cmd(self):
         if self.disk_created:
-            await self._run_cmd("initial-cmd")
-        await self._run_cmd("cmd")
+            if self.qemu_config.get("initial-cmd-file"):
+                await self._run_cmd("initial-cmd-file", is_file=True, in_qemu_conf=True)
+            else:
+                await self._run_cmd("initial-cmd", in_qemu_conf=True)
+
+        if self.config.get("cmd-file"):
+            await self._run_cmd("cmd-file", is_file=True)
+        else:
+            await self._run_cmd("cmd")
 
         # stdout and err both combined into logfile from the spawned repl
         if self.cmdrepl:
@@ -2591,7 +2628,8 @@ users:
 
         use_stdio = cc.get("stdio", True)
         has_cmd = self.config.get("cmd")
-        use_cmdcon = has_cmd and use_stdio
+        has_cmd_file = self.config.get("cmd-file")
+        use_cmdcon = (has_cmd or has_cmd_file) and use_stdio
 
         #
         # Any extra serial/console ports beyond thw first, require entries in

--- a/tests/config/cmd/cmd-noshebang.sh
+++ b/tests/config/cmd/cmd-noshebang.sh
@@ -1,0 +1,1 @@
+echo "foo"

--- a/tests/config/cmd/cmd.sh
+++ b/tests/config/cmd/cmd.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "foo"

--- a/tests/config/cmd/munet.yaml
+++ b/tests/config/cmd/munet.yaml
@@ -1,0 +1,15 @@
+version: 1
+topology:
+  nodes:
+    - name: h-shcmd
+      cmd: echo foo
+    - name: h-shcmd-file
+      cmd-file: "cmd.sh"
+    - name: h-pycmd
+      cmd: print("foo")
+      shell: "/usr/bin/python3"
+    - name: h-pycmd-file
+      cmd-file: "pycmd.py"
+    - name: h-shcmd-file-noshebang
+      cmd-file: "cmd-noshebang.sh"
+

--- a/tests/config/cmd/pycmd.py
+++ b/tests/config/cmd/pycmd.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# May 20 2025, Liam Brady <lbrady@labn.net>
+#
+# Copyright 2021, LabN Consulting, L.L.C.
+#
+
+"Python script used to test the function of cmd-file config"
+
+print("foo")

--- a/tests/config/cmd/test_namespace_cmd.py
+++ b/tests/config/cmd/test_namespace_cmd.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# May 20 2025, Liam Brady <lbrady@labn.net>
+#
+# Copyright 2021, LabN Consulting, L.L.C.
+#
+"Testing of cmd and cmd-file config for L3NamespaceNode"
+import logging
+
+import pytest
+
+
+# All tests are coroutines
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.parametrize("host", ["h-shcmd", "h-shcmd-file", "h-pycmd", "h-pycmd-file",
+                                  "h-shcmd-file-noshebang"])
+async def test_config_cmd(unet_share, host):
+    unet = unet_share
+    rn = unet.hosts[host]
+    output = rn.cmd_raises("cat cmd*.out")
+    logging.debug("expects to find 'foo' in cmd.out; Found: %s", output)
+    assert "foo" in output

--- a/tests/qemu/config/initial-cmd/cmd-initial-qemu.sh
+++ b/tests/qemu/config/initial-cmd/cmd-initial-qemu.sh
@@ -1,0 +1,1 @@
+touch ~/bar

--- a/tests/qemu/config/initial-cmd/cmd-qemu.sh
+++ b/tests/qemu/config/initial-cmd/cmd-qemu.sh
@@ -1,0 +1,1 @@
+touch ~/foo

--- a/tests/qemu/config/initial-cmd/munet-vm.yaml
+++ b/tests/qemu/config/initial-cmd/munet-vm.yaml
@@ -1,0 +1,94 @@
+topology:
+  ipv6-enable: false
+  networks-autonumber: true
+  dns-network: "mgmt0"
+  networks:
+    - name: mgmt0
+      ip: 192.168.0.254/24
+      nat: true
+  nodes:
+    - name: h1
+      connections:
+        - to: "mgmt0"
+        - to: "r1"
+          ip: 10.0.1.1/24
+        - to: "r2"
+          ip: 10.0.2.1/24
+    - name: r1
+      kind: disk-linux-from-file
+      cmd-file: "cmd-qemu.sh"
+      connections:
+        - to: "mgmt0"
+        - to: "h1"
+          ip: 10.0.1.2/24
+    - name: r2
+      kind: disk-linux
+      cmd: "touch ~/foo"
+      connections:
+        - to: "mgmt0"
+        - to: "h1"
+          ip: 10.0.2.2/24
+
+kinds:
+  - name: disk-linux-from-file
+    ssh-identity-file: "%RUNDIR%/../root-key"
+    ssh-user: "root"
+    qemu:
+      disk-template: "%CONFIGDIR%/ubuntu-tpl.qcow2"
+      cloud-init: true
+      cloud-init-disk: "%RUNDIR%/../%NAME%-config-cmd.img"
+      initial-cmd-file: "cmd-initial-qemu.sh"
+      console:
+        user: "root"
+        password: "foobar"
+        timeout: 3600
+      memory: "1G"
+      kvm: true
+      ncpu: 2
+  - name: disk-linux
+    ssh-identity-file: "%RUNDIR%/../root-key"
+    ssh-user: "root"
+    qemu:
+      disk-template: "%CONFIGDIR%/ubuntu-tpl.qcow2"
+      cloud-init: true
+      cloud-init-disk: "%RUNDIR%/../%NAME%-config-cmd.img"
+      initial-cmd: "touch ~/bar"
+      console:
+        user: "root"
+        password: "foobar"
+        timeout: 3600
+      memory: "1G"
+      kvm: true
+      ncpu: 2
+
+
+cli:
+  commands:
+    - name: con
+      exec: "socat /dev/stdin,rawer,escape=0x1d,,echo=0,icanon=0 unix-connect:%RUNDIR%/s/vcon0"
+      format: "con HOST [HOST ...]"
+      help: "open console on given hosts, * for all"
+      new-window: true
+      top-level: true
+    - name: mon
+      exec: "socat /dev/stdin,rawer,escape=0x1d,,echo=0,icanon=0 unix-connect:%RUNDIR%/s/monitor"
+      format: "mon NODE [NODE ...]"
+      help: "open monitor on given hosts, * for all"
+      new-window: true
+      top-level: true
+    - name: ssh
+      exec: "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null %IPADDR%"
+      kinds: ["disk-linux", "disk-linux-from-file"]
+      format: "ssh NODE [NODE ...]"
+      top-level: true
+      new-window: true
+    - name: sship
+      exec: "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {}"
+      format: "sship [user@]ip-addr"
+      top-level: true
+      new-window: true
+    - name: vtysh
+      exec: "expect -c 'spawn ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null %IPADDR% ; expect \"assword:\"; send \"\n\"; interact'"
+      format: "vtysh NODE"
+      top-level: true
+      new-window: true

--- a/tests/qemu/config/initial-cmd/r1-netcfg.yaml
+++ b/tests/qemu/config/initial-cmd/r1-netcfg.yaml
@@ -1,0 +1,25 @@
+version: 2
+ethernets:
+  nic0:
+    match:
+      macaddress: "02:aa:aa:aa:00:02"
+    set-name: eth0
+  nic1:
+    match:
+      macaddress: "02:aa:aa:aa:01:02"
+    set-name: eth1
+  eth0:
+    dhcp4: false
+    dhcp6: false
+    addresses:
+      - 192.168.0.2/24
+    gateway4: 192.168.0.254
+    nameservers:
+      addresses:
+        - 8.8.8.8
+        - 8.8.4.4
+  eth1:
+    dhcp4: false
+    dhcp6: false
+    addresses:
+      - 10.0.1.2/24

--- a/tests/qemu/config/initial-cmd/r2-netcfg.yaml
+++ b/tests/qemu/config/initial-cmd/r2-netcfg.yaml
@@ -1,0 +1,25 @@
+version: 2
+ethernets:
+  nic0:
+    match:
+      macaddress: "02:aa:aa:aa:00:03"
+    set-name: eth0
+  nic1:
+    match:
+      macaddress: "02:aa:aa:aa:01:03"
+    set-name: eth1
+  eth0:
+    dhcp4: false
+    dhcp6: false
+    addresses:
+      - 192.168.0.2/24
+    gateway4: 192.168.0.254
+    nameservers:
+      addresses:
+        - 8.8.8.8
+        - 8.8.4.4
+  eth1:
+    dhcp4: false
+    dhcp6: false
+    addresses:
+      - 10.0.1.2/24

--- a/tests/qemu/config/initial-cmd/test_qemu_cmd.py
+++ b/tests/qemu/config/initial-cmd/test_qemu_cmd.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# June 6 2025, Liam Brady <lbrady@labn.net>
+#
+# Copyright 2025, LabN Consulting, L.L.C.
+#
+"Tests of initial-cmd-file and cmd-file config for L3QemuNode"
+import logging
+import os
+
+import pytest
+
+from munet.base import commander
+
+
+# All tests are coroutines
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.parametrize("unet", ["munet-vm"], indirect=["unet"]),
+]
+
+
+@pytest.fixture(autouse=True, scope="module")
+async def setup_images(rundir_module):
+    try:
+        rdir = rundir_module
+        release = "22.04"
+        # This is actually a qcow2 image regardless of the .img suffix
+        bimage = f"ubuntu-{release}-server-cloudimg-amd64.img"
+        image_url = (
+            f"https://cloud-images.ubuntu.com/releases/{release}/release/{bimage}"
+        )
+        qimage = "ubuntu-tpl.qcow2"
+
+        if not os.path.exists(bimage):
+            commander.cmd_raises(f"curl -fLO {image_url}")
+
+        if not os.path.exists(qimage):
+            commander.cmd_raises(f"rm -f {qimage} && ln -sf {bimage} {qimage}")
+
+        if not os.path.exists(f"{rdir}/root-key"):
+            commander.cmd_raises(
+                f'ssh-keygen -b 2048 -t rsa -f {rdir}/root-key -q -N ""'
+            )
+        pubkey = commander.cmd_raises(f"cat {rdir}/root-key.pub").strip()
+        for node in ["r1", "r2"]:
+            user_data = f"""#cloud-config
+disable_root: 0
+ssh_pwauth: 1
+users:
+  - name: root
+    lock_passwd: false
+    plain_text_passwd: foobar
+    ssh_authorized_keys:
+      - "{pubkey}"
+hostname: {node}
+runcmd:
+  - systemctl enable serial-getty@ttyS1.service
+  - systemctl start serial-getty@ttyS1.service
+  - systemctl enable serial-getty@ttyS2.service
+  - systemctl start serial-getty@ttyS2.service
+"""
+            commander.cmd_raises(f"cat > {rdir}/{node}-user-data.yaml", stdin=user_data)
+            commander.cmd_raises(
+                f"cloud-localds -N {node}-netcfg.yaml -d raw"
+                f" {rdir}/{node}-config-cmd.img {rdir}/{node}-user-data.yaml"
+            )
+    except Exception:
+        pytest.fail("Failed to fetch/setup qemu images")
+
+
+async def test_qemu_up(unet):
+    r1 = unet.hosts["r1"]
+    output = r1.monrepl.cmd_nostatus("info status")
+    assert output == "VM status: running"
+    r2 = unet.hosts["r2"]
+    output = r2.monrepl.cmd_nostatus("info status")
+    assert output == "VM status: running"
+
+
+async def test_config_cmd(unet):
+    r1 = unet.hosts["r1"]
+    r2 = unet.hosts["r2"]
+
+    output = r1.conrepl.cmd_raises("ls")
+    logging.debug(output)
+    assert 'foo' in output  # from cmd-file
+    assert 'bar' in output  # from initial-cmd-file
+
+    output = r2.conrepl.cmd_raises("ls")
+    logging.debug(output)
+    assert 'foo' in output  # from cmd
+    assert 'bar' in output  # from initial-cmd


### PR DESCRIPTION
Allows a user to configure `cmd` or `initial-cmd`
by reading from a file instead of specifying the
full command within the munet.yaml config. This
breaks up the config and should make it easier
to work with in the case of router VMs, etc.

The yang scheme is also updated in order
to reference these new config options.