### PR TITLE
munet: add Commander.async_spawn()

### DIFF
--- a/munet/native.py
+++ b/munet/native.py
@@ -931,7 +931,12 @@ ff02::2\tip6-allrouters
         logfile_read = open(lfname, "a+", encoding="utf-8")
         logfile_read.write("-- start read logging for: '{}' --\n".format(sock))
 
-        p = self.spawn(sock, prompt, logfile=logfile, logfile_read=logfile_read)
+        p = await self.async_spawn(
+            sock,
+            prompt,
+            logfile=logfile,
+            logfile_read=logfile_read,
+        )
         from .base import ShellWrapper  # pylint: disable=C0415
 
         p.send("\n")

--- a/tests/control/test_spawn.py
+++ b/tests/control/test_spawn.py
@@ -9,8 +9,10 @@
 import logging
 import os
 import time
-
+import pexpect
 import pytest
+
+import munet
 
 
 # All tests are coroutines
@@ -53,7 +55,7 @@ async def _test_repl(unet, hostname, cmd, use_pty, will_echo=False):
 @pytest.mark.parametrize("host", ["host1", "container1", "remote1", "hn1"])
 @pytest.mark.parametrize("mode", ["pty", "piped"])
 @pytest.mark.parametrize("shellcmd", ["/bin/bash", "/bin/dash", "/usr/bin/ksh"])
-async def test_spawn(unet_share, host, mode, shellcmd):
+async def test_shell_expect(unet_share, host, mode, shellcmd):
     unet = unet_share
     if not os.path.exists(shellcmd):
         pytest.skip(f"{shellcmd} not installed skipping")
@@ -98,3 +100,104 @@ async def test_spawn(unet_share, host, mode, shellcmd):
         # this is required for setns() restoration to work for non-pty (piped) bash
         if mode != "pty":
             repl.child.proc.kill()
+
+
+@pytest.mark.parametrize("host_name", ["host1", "container1", "remote1", "hn1"])
+@pytest.mark.parametrize("mode", ["pty", "piped"])
+@pytest.mark.parametrize("shellcmd", ["/bin/bash", "/bin/dash", "/usr/bin/ksh"])
+# As of 6-24-25, spawn is unused in the munet API. It is still maintained for the future
+async def test_spawn(unet_share, host_name, mode, shellcmd):
+    unet = unet_share
+    if not os.path.exists(shellcmd):
+        pytest.skip(f"{shellcmd} not installed skipping")
+
+    use_pty = mode == "pty"
+    prompt = r"(^|\r?\n)[^#\$]*[#\$] "
+
+    if use_pty:
+        cmd = [shellcmd]
+    else:
+        cmd = [shellcmd, "-si"]
+
+    host = unet.hosts[host_name]
+    time.sleep(1)
+
+    p = host.spawn(
+        cmd,
+        prompt,
+        use_pty=use_pty,
+        timeout=1,
+    )
+
+    p.send("\n")
+
+    # Sanity check, create a value in p's STDOUT that doesn't appear within p's STDIN
+    p.send("echo $(( 3 * 7 )) \n")
+
+    try:
+        index = p.expect([r"21"], timeout=1)
+        assert index == 0
+    except pexpect.TIMEOUT:
+        host.logger.critical(
+            "test_spawn: Expect failed with the process returned by spawn()"
+        )
+        assert False
+    finally:
+        p.kill(9)
+
+
+@pytest.mark.parametrize("mode", ['async', 'sync'])
+@pytest.mark.parametrize("catch_err", ["timeout", "eof"])
+async def test_spawn_err(unet_share, mode, catch_err):
+    unet = unet_share
+    hostname = "host1"
+    prompt = r"foo"
+    expects = ["bar"]
+    sends = ["baz"]
+
+    if catch_err == "timeout":
+        expected_error = pexpect.TIMEOUT
+        cmd = ["/bin/bash"]
+    elif catch_err == "eof":
+        expected_error = munet.base.CalledProcessError
+        # A command that exits instantly results in a broken pipe
+        cmd = ["/bin/sleep", "1"]
+
+    host = unet.hosts[hostname]
+    time.sleep(1)
+
+    saved_level = host.logger.getEffectiveLevel()
+    # Hide expected error messages for duration of test
+    host.logger.setLevel(logging.CRITICAL)
+
+    p = None
+    try:
+        if mode == 'async':
+            p = await host.async_spawn(
+                cmd,
+                prompt,
+                expects=expects,
+                sends=sends,
+                use_pty=False,
+                echo=False,
+                timeout=1,
+            )
+            host.logger.critical("test_spawn_err: async_spawn unexpectedly succeeded")
+        else:
+            p = host.spawn(
+                cmd,
+                prompt,
+                expects=expects,
+                sends=sends,
+                use_pty=False,
+                echo=False,
+                timeout=1,
+            )
+            host.logger.critical("test_spawn_err: spawn unexpectedly succeeded")
+        assert False
+    except expected_error:
+        pass
+    finally:
+        host.logger.setLevel(saved_level)  # Revert to initial logging level
+        if p is not None:
+            p.kill(9)


### PR DESCRIPTION
spawn(), which conducts a send/expect process is
blocking due to the abscence of async_=True to
pexpect.expect() within the method's main
send/expect loop. Some async methods call
spawn(), however, which leads to such methods
being blocked.

This is particularly problematic in cases where
multiple VMs requiring custom console expect/send
prompts are required (e.g. routers). Since each
QEMU VM sets up both console logging and completes
an expect/send loop without yielding control to
the coroutine of the other QEMU VMs, only one VM
can ever have logging configured (and thus advance in
an expect/send loop) at any given time. Not
only is this inefficient given that all QEMU VMs
are running and waiting for input, but this can
be fatal if console logging is not set up on each
VM in time. If some mandatory console output is
missed, then there is no way to recover and the
setup of the QEMU VM will time out.

However, setting async_=True in pexpect.expect()
leads to errors when mixed with PopenSpawn.
To bypass this issue, we do not use pexpect.expect()
with async_=True, but repeatedly call
pexpect.expect() with a timeout set at 0.1 (Until
a timeout that we track expires).

The end result of this change is that both logging is set
up on all QEMU nodes immediately and that
independent progress can be made in each VM's
expect/send loop simultaneously.