### PR TITLE
mutest: do even deeper inspection during DeepDiff for in-exect matching

### DIFF
--- a/munet/mutest/userapi.py
+++ b/munet/mutest/userapi.py
@@ -574,7 +574,11 @@ class TestCase:
             json_diff = json.loads(deep_diff.to_json())
         else:
             deep_diff = json_cmp(
-                expect, js, ignore_order=True, cutoff_intersection_for_pairs=1
+                expect,
+                js,
+                ignore_order=True,
+                cutoff_intersection_for_pairs=1,
+                cutoff_distance_for_pairs=1,
             )
             # Convert DeepDiff completely into dicts or lists at all levels
             json_diff = json.loads(deep_diff.to_json())

--- a/tests/mutest/mutest_matchwait_json.py
+++ b/tests/mutest/mutest_matchwait_json.py
@@ -330,6 +330,21 @@ match_step_json(
     exact_match=False,
 )
 
+# This case only passes when json_cmp (DeepDiff) is given
+# the arg `cutoff_distance_for_pairs` at 0.4 or higher
+# the default value is 0.3.
+full = '[{"1one": 1, "1two": 2, "1three": 3, "1four": 4, "1five": 5, "1six": 6}, {"2one": 1, "2two": 2, "2three": 3, "2four": 4, "2five": 5, "2six": 6}]'
+subset = '[{"2three": 3}]'
+
+match_step_json(
+    "r1",
+    f"echo '{full}'",
+    subset,
+    "Verify alternate subset matches full",
+    expect_fail=False,
+    exact_match=False,
+)
+
 section("Test json errors")
 
 jsonblank = '{}'


### PR DESCRIPTION
previously, cutoff_intersection_for_pairs was set to 1 in order to provide a deeper inspection of dictionaries within lists using DeepDiff (See: 7e9f484ad7dc7d1c579a9c1523ddf560332c0756). However, it's sister option, cuttoff_distance_for_pairs, was not also set.

This leads to some situations where the json would still not match. Specifically, this was found to occur in cases where dictionaries within a list contain many members.