### PR TITLE
docs: alternate install instructions

### DIFF
--- a/README.org
+++ b/README.org
@@ -316,6 +316,10 @@ cisco VM using a nexos file system image.
 
 ** Development
 
+For most users, it is recommended to install munet through pip (see:
+https://munet.readthedocs.io/en/latest/usage.html). However, if you want to run
+the unit tests, then you will need to set up your local enviornment:
+
 *** Dependencies
 
 μNET requires the following packages:

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -17,6 +17,12 @@ Install munet using pip:
 
    $ pip install munet
 
+Or if you need the latest changes from master:
+
+.. code-block:: console
+
+   $ pip install git+https://github.com/LabNConsulting/munet.git#egg=munet
+
 Running
 -------
 


### PR DESCRIPTION
When updates are made on master but no release cut, it is unclear to a user as to how to aquire the recent fixes or changes. The set of developer steps is sufficient to run the unit tests, but is not applicable to a wide range of dev environments where munet/mutest is in use.

Conveniently, you can install munet with all the latest changes from github using pip. This change guides the user to such an option if they need the latest updates.