### PR TITLE
munet: fix issue with `add_netns()` in parallel runs

### DIFF
--- a/munet/base.py
+++ b/munet/base.py
@@ -2730,12 +2730,6 @@ class BaseMunet(LinuxNamespace):
 
         self.hosts[name] = cls(name, unet=self, **kwargs)
 
-        # Create a new mounted FS for tracking nested network namespaces creatd by the
-        # user with `ip netns add`
-
-        # XXX why is this failing with podman???
-        # self.hosts[name].tmpfs_mount("/run/netns")
-
         return self.hosts[name]
 
     def add_link(self, node1, node2, if1, if2, mtu=None, **intf_constraints):

--- a/munet/native.py
+++ b/munet/native.py
@@ -1242,6 +1242,11 @@ class L3NamespaceNode(L3NodeMixin, LinuxNamespace):
         #     kwargs,
         # )
         super().__init__(name, pid=pid, **kwargs)
+
+        # Create a new mounted FS for tracking nested network namespaces creatd by the
+        # user with `ip netns add`
+        self.tmpfs_mount("/run/netns")
+
         super().pytest_hook_open_shell()
 
     async def _async_delete(self):
@@ -2676,11 +2681,11 @@ users:
         if self.disk_created:
             password = cc.get("initial-password", password)
 
-        expects=cc.get("expects")
+        expects = cc.get("expects")
         if expects is not None:
             for expect_str in expects:
                 expect_str.replace("%NAME%", str(self.name))
-        sends=cc.get("sends")
+        sends = cc.get("sends")
         if sends is not None:
             for send_str in sends:
                 send_str.replace("%NAME%", str(self.name))


### PR DESCRIPTION
We need a new `/run/netns` tmpfs for each node/ns, otherwise parallel runs are colliding with each other when using `ip netns add` which creates entries under `/run/netns`.

We only need this for L3LinuxNamespace though (the other types create there own (containers and vms) or don't support tmpfs (ssh). Also, move the original code out of BaseMunet and into the L3LinuxNamespace __init__().