### PR TITLE
readthedocs: fix doc build failures

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,9 +8,12 @@ build:
       # Install poetry
       - pip install poetry~=1.2
       # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create false
+      #- poetry config virtualenvs.create false
     post_install:
       # Install dependencies
       - poetry install --with doc
+      # Install dependencies to the correct site-packages
+      - poetry run pip freeze > reqs.txt
+      - pip install --upgrade -r reqs.txt
 sphinx:
   configuration: doc/source/conf.py


### PR DESCRIPTION
For some reason, poetry does not install dependencies to the correct site-package in the read the docs enviornment. As a temporary fix, we can `pip freeze` the packages that poetry installs within a venv and reinstall them to the correct site-packages by directly using pip.

I don't think it is worth it to investigate and determine a permanent fix given the ongoing discussion of swapping out poetry with uv.