### PR TITLE
munet: fix desync after send/expect

### DIFF
--- a/munet/base.py
+++ b/munet/base.py
@@ -886,7 +886,6 @@ class Commander:  # pylint: disable=R0904
         use_pty=False,
         will_echo=False,
         is_bourne=True,
-        init_newline=False,
         **kwargs,
     ):
         """Create a shell REPL (read-eval-print-loop).
@@ -901,8 +900,6 @@ class Commander:  # pylint: disable=R0904
                 be the empty string to send nothing.
             is_bourne: if False then do not modify shell prompt for internal
                 parser friently format, and do not expect continuation prompts.
-            init_newline: send an initial newline for non-bourne shell spawns, otherwise
-                expect the prompt simply from running the command
             use_pty: true for pty based expect, otherwise uses popen (pipes/files)
             will_echo: bash is buggy in that it echo's to non-tty unlike any other
                 sh/ksh, set this value to true if running back
@@ -923,8 +920,6 @@ class Commander:  # pylint: disable=R0904
         assert not p.echo
 
         if not is_bourne:
-            if init_newline:
-                p.send("\n")
             return ShellWrapper(p, prompt, will_echo=will_echo)
 
         ps1 = PEXPECT_PROMPT

--- a/munet/native.py
+++ b/munet/native.py
@@ -2290,7 +2290,6 @@ class L3QemuVM(L3NodeMixin, LinuxNamespace):
                         expects=expects,
                         sends=sends,
                         timeout=timeout,
-                        init_newline=True,
                         trace=True,
                     )
                 )


### PR DESCRIPTION
spawn() within shell_spawn() already provides a newline when no shell/login prompt is found. Sending a second newline after the expected prompt is detected results in a desync in the console I/O. This is because response received from sending the newline is not consumed.

Thus, any future instance after the desync of cmd_nostatus() or cmd_status() after shell_spawn() finishes either throws a warning or an error. The instability due to the desync can break following features that rely on such functionality, such as the mounting of shared volumes into the QEMU VM.

As a bonus, this also cleans up the output of the `_console-log.txt` files created for QEMU nodes. The I/O sequence is *a lot* easier to follow when there is no desync present.