### PR TITLE
mutest: mutest groups

### DIFF
--- a/doc/source/mutest.rst
+++ b/doc/source/mutest.rst
@@ -27,11 +27,28 @@ any founc test scripts simply run the command:
    $ sudo mutest
 
 Mutest will then search the current directory and sub-directories for all files
-matching the shell glob pattern ``mutest_*.py`` and co-reside with a munet
-topology configuration ``munet.yaml``. Finding both it will then launch a munet
-topology with the given configuration file and execute each test on the
-resulting topology. The munet topology is launched at the start and brought down
-at the end of each test script.
+matching the shell glob pattern ``mutest_*.py`` and that either co-reside with a
+munet topology configuration ``munet.yaml`` or exist in a subdirectory of a
+munet topology containing a configuration ``munet.yaml``. Finding both, it will
+then launch instances of the munet topology with the given configuration file
+and execute each test on the resulting topologies according to the following
+rules:
+
+* Test files co-residing with a munet topology configuration ``munet.yaml`` are
+  run within their own munet topology instance. The topology is launched at the
+  start and brought down at the end of each of these test scripts.
+* Test files found within the subdirectory of a munet topology containing a
+  configuration ``munet.yaml`` are considered to be of the same ``group``. Tests
+  in the same ``group`` share a single instance of a munet topology instance.
+
+.. code-block::
+
+   topology-root
+   |--munet.yaml
+   |--mutest_singleton.py  <-- runs within own topology instance
+   |--grouped-tests
+      |--mutest_01_first.py   <-- both of these tests share
+      |--mutest_02_second.py  <-- the same topology instance
 
 Log Files
 ---------

--- a/munet/mutest/userapi.py
+++ b/munet/mutest/userapi.py
@@ -197,7 +197,7 @@ class TestCase:
 
     def __init__(
         self,
-        tag: int,
+        tag: str,
         name: str,
         path: Path,
         targets: dict,

--- a/tests/mutest/test_groups/mutest_01_groups_first.py
+++ b/tests/mutest/test_groups/mutest_01_groups_first.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# August 21 2025, Liam Brady <lbrady@labn.net>
+#
+# Copyright (c) 2025, LabN Consulting, L.L.C.
+#
+"""Test groups (First half of test).
+
+This test is part of a pair written to ensure that mutests within the
+same group are run within the same topology instance. This allows one
+test to affect the running state for subsequent tests.
+"""
+from munet.mutest.userapi import step
+from munet.mutest.userapi import match_step
+
+
+step("r1", 'echo "bar" > foo.txt')
+
+match_step("r1", 'cat foo.txt', r"bar", "Created a temporary file")

--- a/tests/mutest/test_groups/mutest_99_groups_last.py
+++ b/tests/mutest/test_groups/mutest_99_groups_last.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# August 21 2025, Liam Brady <lbrady@labn.net>
+#
+# Copyright (c) 2025, LabN Consulting, L.L.C.
+#
+"""Test groups (second half of test).
+
+This test is part of a pair written to ensure that mutests within the
+same group are run within the same topology instance. This allows one
+test to affect the running state for subsequent tests.
+"""
+from munet.mutest.userapi import match_step
+
+
+match_step(
+    "r1",
+    'cat foo.txt',
+    r"bar",
+    "Found a temporary file created in a previous mutest",
+)


### PR DESCRIPTION
Multiple mutests found within a subdirectory of a munet topology are newly interpreted as a single 'group' of mutests. A group of mutests share the same munet topology instance when running. This allows a developer to avoid the cost of spinning up a new topology for each mutest where it is not needed.

This native support obsoletes the need for (but continues to make available) developer-defined 'loader' mutests that include other test files in order to run them all within a single instance of a munet topology.