### PR TITLE
docs: readthedocs build fix

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,5 +8,7 @@ build:
     #   - pip install uv
     post_install:
       - pip install --editable .
+      # Installing from dependency groups (e.g. 'dev') is not yet supported.
+      - pip install sphinx-prompt
 sphinx:
   configuration: doc/source/conf.py


### PR DESCRIPTION
Adds the missing sphinx-prompt dependency to the build process. This dependency is part of the 'dev' dependency group, however, it is currently not possible to install dependency groups to the system site-package (either with pip or uv).

link to the built documentation with this fix: https://munet.readthedocs.io/en/liambrady-docs_fix_2/

closes #76 