### PR TITLE
munet: fix --pcaps=all

### DIFF
--- a/munet/native.py
+++ b/munet/native.py
@@ -3405,11 +3405,12 @@ done"""
             self.coverage_setup()
 
         pcapopt = self.cfgopt.getoption("--pcap")
-        pcapopt = pcapopt if pcapopt else ""
-        if pcapopt == "all":
-            pcapopt = self.switches.keys()
+        pcapopt = set(pcapopt.split(",")) if pcapopt else set()
+        if 'all' in pcapopt:
+            pcapopt.remove('all')
+            pcapopt.update(self.switches.keys())
         if pcapopt:
-            for pcap in pcapopt.split(","):
+            for pcap in pcapopt:
                 if ":" in pcap:
                     host, intf = pcap.split(":")
                     pcap = f"{host}-{intf}"


### PR DESCRIPTION
Fix a bug where self.switches.keys() does not have the split() method, and as a result, throws an error when 'all' is passed instead of the specific networks or interfaces.

Note that 'all' will include all networks with this fix but does not start pcaps for specific interfaces. Interfaces must still be specified as NODE:INTF.