### PR TITLE
tests: longer Qemu startup timeout

### DIFF
--- a/tests/qemu/munet-cloud.yaml
+++ b/tests/qemu/munet-cloud.yaml
@@ -65,10 +65,10 @@ kinds:
       # disk-template: "https://dl.rockylinux.org/pub/rocky/7/images/x86_64/Rocky-8-GenericCloud-Base.latest.x86_64.qcow2"
       # disk-template: "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base.latest.x86_64.qcow2"
       cloud-init: true
-      # console:
+      console:
       #   user: "root"
       #   password: "foobar"
-      #   timeout: 3600
+        timeout: 600
       memory: "1G"
       kvm: true
       ncpu: 2

--- a/tests/qemu/munet-vm.yaml
+++ b/tests/qemu/munet-vm.yaml
@@ -31,7 +31,7 @@ kinds:
       console:
         user: "root"
         password: "foobar"
-        timeout: 3600
+        timeout: 600
       memory: "1G"
       kvm: true
       ncpu: 2

--- a/tests/qemu/munet.yaml
+++ b/tests/qemu/munet.yaml
@@ -20,6 +20,8 @@ kinds:
       kernel: "%CONFIGDIR%/bzImage"
       initrd: "%CONFIGDIR%/rootfs.cpio.gz"
       cmdline-extra: "nokaslr"
+      console:
+        timeout: 600
       memory: "1G"
       kvm: true
       ncpu: 2


### PR DESCRIPTION
Increase the console timeout values of multiple tests. This prevents premature failures from being thrown within the github CI.

Note: I ran the github CI ~8 times on my munet fork with no recorded timeout-related issues.